### PR TITLE
add top half of time table css

### DIFF
--- a/dluhc-component-library/src/components/timetablePage/Timetable.tsx
+++ b/dluhc-component-library/src/components/timetablePage/Timetable.tsx
@@ -47,7 +47,7 @@ const Timetable = ({ data }: StagesProps) => {
     getCoreRowModel: getCoreRowModel(),
   });
   return (
-    <div className="px-4">
+    <div>
       <table className="w-full text-sm text-left px-4">
         <thead className="capitalise text-left font-bold border-b">
           {table.getHeaderGroups().map((headerGroup) => (
@@ -56,7 +56,7 @@ const Timetable = ({ data }: StagesProps) => {
                 <th key={header.id} className="py-3">
                   {flexRender(
                     header.column.columnDef.header,
-                    header.getContext()
+                    header.getContext(),
                   )}
                 </th>
               ))}

--- a/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
+++ b/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
@@ -24,13 +24,13 @@ const TimetablePage = ({ filepath }: TimetablePageProps) => {
           <h1 className="my-16 text-3xl font-bold">
             Birmingham New Local Plan Timetable
           </h1>
-          <p className="w-1/2 text-lg mb-8">
+          <p className="w-2/3 text-lg mb-8">
             We are working on a new Local Plan for Birmingham which will guide
             how the city will develop in the future and provide policies to
             guide decisions on development proposals and planning applications
             up to 2042.
           </p>
-          <p className="w-1/2 mb-8 text-lg">
+          <p className="w-2/3 mb-8 text-lg">
             This page provides updates on the progress of our New Local Plan.
           </p>
         </div>

--- a/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
+++ b/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
@@ -20,29 +20,40 @@ const TimetablePage = ({ filepath }: TimetablePageProps) => {
   return (
     <>
       <div>
-        <h1>Birmingham New Local Plan Timetable</h1>
-        <p>
-          We are working on a new Local Plan for Birmingham which will guide how
-          the city will develop in the future and provide policies to guide
-          decisions on development proposals and planning applications up to
-          2042.
-        </p>
-      </div>
-      <div>
         <div>
-          <p>Published some day</p>
-          <p>last updated some day</p>
+          <h1 className="my-16 text-3xl font-bold">
+            Birmingham New Local Plan Timetable
+          </h1>
+          <p className="w-1/2 text-lg mb-8">
+            We are working on a new Local Plan for Birmingham which will guide
+            how the city will develop in the future and provide policies to
+            guide decisions on development proposals and planning applications
+            up to 2042.
+          </p>
+          <p className="w-1/2 mb-8 text-lg">
+            This page provides updates on the progress of our New Local Plan.
+          </p>
+        </div>
+        <hr className="my-8"></hr>
+        <div>
+          <div className="my-8">
+            <p className="text-sm">Published 5 january 2023</p>
+            <p className="text-sm">
+              last updated 5 january 2023 -
+              <span className="text-blue-400 underline"> See all updates</span>
+            </p>
+          </div>
+          <div>
+            <p>Status: New Local Plan</p>
+            <p>Period: 2022 - 2042</p>
+            <p>Coverage: City Wide</p>
+            <a className="text-blue-400 underline">➤ More Information</a>
+          </div>
         </div>
         <div>
-          <p>Status: New Local Plan</p>
-          <p>Period: 2022 - 2042</p>
-          <p>Coverage: City Wide</p>
-          <a>More Information</a>
+          <h2 className="mb-6 mt-12 text-xl font-bold">Timetable</h2>
+          <Timetable data={timetableData} />
         </div>
-      </div>
-      <div>
-        <h2>Timetable</h2>
-        <Timetable data={timetableData} />
       </div>
     </>
   );


### PR DESCRIPTION
adds csv to immitate gov website for the text info in the timetable page 

![image](https://github.com/digital-land/plan-making/assets/110818566/719cf8a7-0e24-4811-a61b-63dd4787f593)
