### PR TITLE
Refactor progress tile and types

### DIFF
--- a/dluhc-component-library/src/components/timetablePage/ProgressTile.tsx
+++ b/dluhc-component-library/src/components/timetablePage/ProgressTile.tsx
@@ -1,13 +1,22 @@
+import { Progress } from "./types";
+
 interface ProgressTileProps {
-  progress: "notStarted" | "delayed" | "inProgress" | "finished";
+  progress: Progress;
 }
+
+const progressTextMap = {
+  notStarted: "Not started",
+  delayed: "Delayed",
+  inProgress: "In progress",
+  finished: "Finished",
+};
 
 const ProgressTile = ({ progress }: ProgressTileProps) => {
   const progressClass = `progress-${progress}`;
 
   return (
     <span className={`uppercase font-semibold py-1 px-2 ${progressClass}`}>
-      {progress}
+      {progressTextMap[progress]}
     </span>
   );
 };

--- a/dluhc-component-library/src/components/timetablePage/Timetable.tsx
+++ b/dluhc-component-library/src/components/timetablePage/Timetable.tsx
@@ -1,40 +1,12 @@
 import {
-  createColumnHelper,
   flexRender,
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { columnDefinitions } from "./columnDefinitions";
+import { RowData } from "./types";
 
 import "./Timetable.css";
-import ProgressTile from "./ProgressTile";
-
-type RowData = {
-  developmentPlanEvent: string;
-  startDate: string;
-  endDate: string;
-  progress: "notStarted" | "delayed" | "inProgress" | "finished";
-};
-
-const columnHelper = createColumnHelper<RowData>();
-
-const columns = [
-  columnHelper.accessor("developmentPlanEvent", {
-    cell: (data) => <span className="font-bold">{data.getValue()}</span>,
-    header: () => <span>Stage</span>,
-  }),
-  columnHelper.accessor("startDate", {
-    cell: (data) => data.getValue(),
-    header: () => <span>Start Date</span>,
-  }),
-  columnHelper.accessor("endDate", {
-    cell: (data) => data.getValue(),
-    header: () => <span>End Date</span>,
-  }),
-  columnHelper.accessor("progress", {
-    cell: (data) => <ProgressTile progress={data.getValue()} />,
-    header: () => <span>Progress</span>,
-  }),
-];
 
 interface StagesProps {
   data?: RowData[];
@@ -43,7 +15,7 @@ interface StagesProps {
 const Timetable = ({ data }: StagesProps) => {
   const table = useReactTable({
     data: data ?? [],
-    columns,
+    columns: columnDefinitions,
     getCoreRowModel: getCoreRowModel(),
   });
   return (

--- a/dluhc-component-library/src/components/timetablePage/columnDefinitions.tsx
+++ b/dluhc-component-library/src/components/timetablePage/columnDefinitions.tsx
@@ -1,0 +1,24 @@
+import { createColumnHelper } from "@tanstack/table-core";
+import { RowData } from "./types";
+import ProgressTile from "./ProgressTile";
+
+const columnHelper = createColumnHelper<RowData>();
+
+export const columnDefinitions = [
+  columnHelper.accessor("developmentPlanEvent", {
+    cell: (data) => <span className="font-bold">{data.getValue()}</span>,
+    header: () => <span>Stage</span>,
+  }),
+  columnHelper.accessor("startDate", {
+    cell: (data) => data.getValue(),
+    header: () => <span>Start Date</span>,
+  }),
+  columnHelper.accessor("endDate", {
+    cell: (data) => data.getValue(),
+    header: () => <span>End Date</span>,
+  }),
+  columnHelper.accessor("progress", {
+    cell: (data) => <ProgressTile progress={data.getValue()} />,
+    header: () => <span>Progress</span>,
+  }),
+];

--- a/dluhc-component-library/src/components/timetablePage/types.ts
+++ b/dluhc-component-library/src/components/timetablePage/types.ts
@@ -1,0 +1,8 @@
+export type Progress = "notStarted" | "delayed" | "inProgress" | "finished";
+
+export type RowData = {
+  developmentPlanEvent: string;
+  startDate: string;
+  endDate: string;
+  progress: Progress;
+};


### PR DESCRIPTION
- Pulls out the column definitions into their own file
- Pulls the types out into a type file
- Converts the progress camel case value into human readable strings

![image](https://github.com/digital-land/plan-making/assets/97245023/c4e824ef-1e20-4777-8458-68a66220ce97)
