### PR TITLE
DLUHC-204 use div ref instead of id for map rendering

### DIFF
--- a/dluhc-component-library/src/components/maps/baseMap.tsx
+++ b/dluhc-component-library/src/components/maps/baseMap.tsx
@@ -3,31 +3,38 @@ import TileLayer from "ol/layer/Tile";
 import { useGeographic } from "ol/proj";
 import { OSM } from "ol/source";
 import { CSSProperties } from "preact/compat";
-import { useEffect, useMemo } from "preact/hooks";
+import { useEffect, useMemo, useRef } from "preact/hooks";
 import "../../../node_modules/ol/ol.css";
 import { useMap } from "../../contexts/mapContext";
 
 interface BaseMapProps {
-  mapId: string;
   lat?: number;
   lng?: number;
   zoom?: number;
+  id?: string;
   className?: string;
   style?: CSSProperties;
 }
 
 const BaseMap = ({
-  mapId,
   lat = 0,
   lng = 0,
   zoom = 0,
+  id,
   className,
   style,
 }: BaseMapProps) => {
   const map = useMap();
-  const props = useMemo(() => ({ className, style }), [className, style]);
+  const props = useMemo(
+    () => ({ id, className, style }),
+    [id, className, style],
+  );
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
     useGeographic();
     map.setLayers([new TileLayer({ source: new OSM() })]);
     map.setView(
@@ -36,10 +43,10 @@ const BaseMap = ({
         zoom,
       }),
     );
-    map.setTarget(mapId);
-  }, [lng, lat, map, mapId, zoom]);
+    map.setTarget(ref.current);
+  }, [lng, lat, map, ref, zoom]);
 
-  return <div id={mapId} {...props} />;
+  return <div ref={ref} {...props} />;
 };
 
 export default BaseMap;

--- a/dluhc-component-library/src/main.tsx
+++ b/dluhc-component-library/src/main.tsx
@@ -35,7 +35,6 @@ const renderMap: RenderFunction = (_options: {}, element: HTMLElement) => {
   render(
     <MapContainer>
       <BaseMap
-        mapId="site-selection-map"
         lat={54.97}
         lng={-1.65}
         zoom={10}

--- a/dluhc-component-library/src/stories/Map.stories.tsx
+++ b/dluhc-component-library/src/stories/Map.stories.tsx
@@ -11,7 +11,6 @@ const MapComponent = ({ lat, lng, zoom }: MapComponentProps) => {
   return (
     <MapContainer>
       <BaseMap
-        mapId="site-selection-map"
         lat={lat}
         lng={lng}
         zoom={zoom}


### PR DESCRIPTION
Makes it easier to render multiple maps at once without needing to have a unique id for each