### PR TITLE
drawn polygon coordinates are used in API request

### DIFF
--- a/dluhc-component-library/src/api/api.ts
+++ b/dluhc-component-library/src/api/api.ts
@@ -1,8 +1,10 @@
-export async function fetchDataset(coordinates: any[][]) {
-  const points = coordinates[0]
-    .map((point: any[]) => `${point[0]} ${point[1]}`)
-    .join(", ");
-  const polygon = `POLYGON((${points}))`;
+import WKT from "ol/format/WKT.js";
+import { Geometry } from "ol/geom";
+
+export async function fetchDataset(geometry: Geometry) {
+  const format = new WKT();
+  const polygon = format.writeGeometry(geometry);
+
   const promise = await fetch(
     `https://www.planning.data.gov.uk/entity.geojson?limit=100&geometry=${polygon}`,
   );

--- a/dluhc-component-library/src/api/api.ts
+++ b/dluhc-component-library/src/api/api.ts
@@ -1,0 +1,10 @@
+export async function fetchDataset(coordinates: any[][]) {
+  const points = coordinates[0]
+    .map((point: any[]) => `${point[0]} ${point[1]}`)
+    .join(", ");
+  const polygon = `POLYGON((${points}))`;
+  const promise = await fetch(
+    `https://www.planning.data.gov.uk/entity.geojson?limit=100&geometry=${polygon}`,
+  );
+  return await promise.json();
+}

--- a/dluhc-component-library/src/api/api.ts
+++ b/dluhc-component-library/src/api/api.ts
@@ -5,8 +5,9 @@ export async function fetchDataset(geometry: Geometry) {
   const format = new WKT();
   const polygon = format.writeGeometry(geometry);
 
-  const promise = await fetch(
+  return await fetch(
     `https://www.planning.data.gov.uk/entity.geojson?limit=100&geometry=${polygon}`,
-  );
-  return await promise.json();
+  ).then((Response) => {
+    return Response.json();
+  });
 }

--- a/dluhc-component-library/src/components/maps/baseMap.tsx
+++ b/dluhc-component-library/src/components/maps/baseMap.tsx
@@ -9,6 +9,8 @@ import { Draw } from "ol/interaction.js";
 import { useMap } from "../../contexts/mapContext";
 import VectorSource from "ol/source/Vector";
 import VectorLayer from "ol/layer/Vector";
+import { Polygon } from "ol/geom";
+import { fetchDataset } from "src/api/api";
 
 interface BaseMapProps {
   lat?: number;
@@ -59,6 +61,11 @@ const BaseMap = ({
     );
     map.setTarget(ref.current);
     map.addInteraction(new Draw({ source: source, type: "Polygon" }));
+    source.on("addfeature", async function (evt) {
+      var feature = evt.feature;
+      var coords = (feature?.getGeometry() as Polygon).getCoordinates();
+      let features = await fetchDataset(coords);
+    });
   }, [lng, lat, map, ref, zoom]);
 
   return <div ref={ref} {...props} />;

--- a/dluhc-component-library/src/components/maps/baseMap.tsx
+++ b/dluhc-component-library/src/components/maps/baseMap.tsx
@@ -61,10 +61,10 @@ const BaseMap = ({
     );
     map.setTarget(ref.current);
     map.addInteraction(new Draw({ source: source, type: "Polygon" }));
-    source.on("addfeature", async function (evt) {
-      var feature = evt.feature;
-      var coords = (feature?.getGeometry() as Polygon).getCoordinates();
-      let features = await fetchDataset(coords);
+    source.on("addfeature", async (evt) => {
+      let feature = evt.feature;
+      let geometry = feature?.getGeometry() as Polygon;
+      let features = await fetchDataset(geometry);
     });
   }, [lng, lat, map, ref, zoom]);
 

--- a/dluhc-component-library/src/components/maps/baseMap.tsx
+++ b/dluhc-component-library/src/components/maps/baseMap.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useRef } from "preact/hooks";
 import "../../../node_modules/ol/ol.css";
 import { Draw } from "ol/interaction.js";
 import { useMap } from "../../contexts/mapContext";
-import VectorSource from "ol/source/Vector";
+import VectorSource, { VectorSourceEvent } from "ol/source/Vector";
 import VectorLayer from "ol/layer/Vector";
 import { Polygon } from "ol/geom";
 import { fetchDataset } from "src/api/api";
@@ -61,7 +61,7 @@ const BaseMap = ({
     );
     map.setTarget(ref.current);
     map.addInteraction(new Draw({ source: source, type: "Polygon" }));
-    source.on("addfeature", async function (evt) {
+    source.on("addfeature", async function (evt: VectorSourceEvent) {
       let feature = evt.feature;
       let geometry = feature?.getGeometry() as Polygon;
       let features = await fetchDataset(geometry);

--- a/dluhc-component-library/src/components/maps/baseMap.tsx
+++ b/dluhc-component-library/src/components/maps/baseMap.tsx
@@ -61,7 +61,7 @@ const BaseMap = ({
     );
     map.setTarget(ref.current);
     map.addInteraction(new Draw({ source: source, type: "Polygon" }));
-    source.on("addfeature", async (evt) => {
+    source.on("addfeature", async function (evt) {
       let feature = evt.feature;
       let geometry = feature?.getGeometry() as Polygon;
       let features = await fetchDataset(geometry);


### PR DESCRIPTION
Data from drawn polygon now makes an API request to PDP to see if any notable sights fall within the bounds of the drawn site.