### PR TITLE
DLUHC-204 add list component for map layers

### DIFF
--- a/dluhc-component-library/src/components/datasets/DatasetList.tsx
+++ b/dluhc-component-library/src/components/datasets/DatasetList.tsx
@@ -1,0 +1,42 @@
+import { useCallback } from "preact/hooks";
+import DatasetSelect from "./DatasetSelect";
+import { Dataset } from "./types";
+
+interface DatasetListProps {
+  title?: string;
+  items: Dataset[];
+  selectedItems: Dataset[];
+  onSelect: (dataset: Dataset) => void;
+}
+
+const DatasetList = ({
+  title = "Data Layers",
+  items,
+  selectedItems,
+  onSelect,
+}: DatasetListProps) => {
+  const isSelected = useCallback(
+    (dataset: string) => selectedItems.some((item) => item.dataset === dataset),
+    [selectedItems],
+  );
+
+  const datasets = items.map((item) => (
+    <DatasetSelect
+      key={item.dataset}
+      item={item}
+      selected={isSelected(item.dataset)}
+      onSelect={onSelect}
+    />
+  ));
+
+  return (
+    <div className="grid border max-h-full overflow-hidden">
+      <div className="text-xl font-bold border-b p-2">{title}</div>
+      <div className="pt-2 px-2 overflow-y-auto overscroll-none">
+        {datasets}
+      </div>
+    </div>
+  );
+};
+
+export default DatasetList;

--- a/dluhc-component-library/src/components/datasets/DatasetSelect.tsx
+++ b/dluhc-component-library/src/components/datasets/DatasetSelect.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from "preact/compat";
+import { Dataset } from "./types";
+
+interface DatasetSelectProps {
+  item: Dataset;
+  selected: boolean;
+  onSelect: (item: Dataset) => void;
+}
+
+const DatasetSelect = ({ item, selected, onSelect }: DatasetSelectProps) => {
+  const id = useMemo(() => `${item.dataset}-checkbox`, [item]);
+
+  return (
+    <div key={item.dataset} className="flex items-center mb-4">
+      <input
+        id={id}
+        className="h-5 w-5 cursor-pointer"
+        type="checkbox"
+        checked={selected}
+        onChange={() => onSelect(item)}
+      />
+      <label htmlFor={id} className="ml-2 font-semibold cursor-pointer">
+        {item.name}
+      </label>
+    </div>
+  );
+};
+
+export default DatasetSelect;

--- a/dluhc-component-library/src/components/datasets/types.ts
+++ b/dluhc-component-library/src/components/datasets/types.ts
@@ -1,0 +1,4 @@
+export interface Dataset {
+  dataset: string;
+  name: string;
+}


### PR DESCRIPTION
- Adds a component that can take a list of datasets and render them as a list. This will be used to select which datasets a LPA is interested in validating.
- The format of datasets matches the response from PDP: https://www.planning.data.gov.uk/dataset.json more fields such as description can be added later if needed.
![image](https://github.com/digital-land/plan-making/assets/47323438/71cd5db4-ebfd-4e61-9b7c-bf7e19b59a46)

In following PRs will add:
- Colour key for each layer
- Render layers based on selection
