### PR TITLE
DLUHC-204 add story for loading planning data platform datasets on a map

### DIFF
--- a/dluhc-component-library/package-lock.json
+++ b/dluhc-component-library/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dluhc-component-library",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^4.33.0",
         "@tanstack/react-table": "^8.9.3",
         "csvtojson": "^2.0.10",
         "ol": "^7.5.0",
@@ -5317,6 +5318,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.33.0.tgz",
+      "integrity": "sha512-qYu73ptvnzRh6se2nyBIDHGBQvPY1XXl3yR769B7B6mIDD7s+EZhdlWHQ67JI6UOTFRaI7wupnTnwJ3gE0Mr/g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.33.0.tgz",
+      "integrity": "sha512-97nGbmDK0/m0B86BdiXzx3EW9RcDYKpnyL2+WwyuLHEgpfThYAnXFaMMmnTDuAO4bQJXEhflumIEUfKmP7ESGA==",
+      "dependencies": {
+        "@tanstack/query-core": "4.33.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -12832,6 +12868,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {

--- a/dluhc-component-library/package.json
+++ b/dluhc-component-library/package.json
@@ -13,6 +13,7 @@
     "build-storybook": "storybook build -o docs-build"
   },
   "dependencies": {
+    "@tanstack/react-query": "^4.33.0",
     "@tanstack/react-table": "^8.9.3",
     "csvtojson": "^2.0.10",
     "ol": "^7.5.0",

--- a/dluhc-component-library/src/api/api.ts
+++ b/dluhc-component-library/src/api/api.ts
@@ -1,3 +1,4 @@
+import { FeatureCollection } from "geojson";
 import WKT from "ol/format/WKT.js";
 import { Geometry } from "ol/geom";
 import { DatasetResponse } from "src/api/types";
@@ -17,3 +18,17 @@ export const fetchDataset = async (geometry: Geometry) => {
 
 export const fetchDatasetList: () => Promise<DatasetResponse> = async () =>
   fetch(`${baseURL}/dataset.json`).then((response) => response.json());
+
+export const fetchEntities: (
+  dataset: string,
+  geometry: Geometry,
+) => Promise<FeatureCollection> = async (dataset, geometry) => {
+  const format = new WKT();
+  const polygon = format.writeGeometry(geometry);
+
+  return await fetch(
+    `${baseURL}/entity.geojson?limit=100&geometry=${polygon}&dataset=${dataset}`,
+  ).then((Response) => {
+    return Response.json();
+  });
+};

--- a/dluhc-component-library/src/components/datasets/DatasetList.tsx
+++ b/dluhc-component-library/src/components/datasets/DatasetList.tsx
@@ -7,6 +7,7 @@ interface DatasetListProps {
   items: Dataset[];
   selectedItems: Dataset[];
   onSelect: (dataset: Dataset) => void;
+  isLoading?: boolean;
 }
 
 const DatasetList = ({
@@ -14,6 +15,7 @@ const DatasetList = ({
   items,
   selectedItems,
   onSelect,
+  isLoading = false,
 }: DatasetListProps) => {
   const isSelected = useCallback(
     (dataset: string) => selectedItems.some((item) => item.dataset === dataset),
@@ -30,10 +32,16 @@ const DatasetList = ({
   ));
 
   return (
-    <div className="grid border max-h-full overflow-hidden">
+    <div className="flex flex-col border max-h-full overflow-hidden">
       <div className="text-xl font-bold border-b p-2">{title}</div>
-      <div className="pt-2 px-2 overflow-y-auto overscroll-none">
-        {datasets}
+      <div className="pt-2 px-2 overflow-y-auto overscroll-none grow flex flex-col">
+        {!isLoading ? (
+          datasets
+        ) : (
+          <div className="text-center flex flex-col justify-center grow">
+            Loading...
+          </div>
+        )}
       </div>
     </div>
   );

--- a/dluhc-component-library/src/components/maps/DatasetLayer.tsx
+++ b/dluhc-component-library/src/components/maps/DatasetLayer.tsx
@@ -1,0 +1,33 @@
+import { Geometry } from "ol/geom";
+import { fetchEntities } from "src/api/api";
+import MapLayer from "./mapLayer";
+import { useQuery } from "@tanstack/react-query";
+import { Dataset } from "src/api/types";
+
+interface DatasetlayerProps {
+  area: Geometry;
+  dataset: Dataset;
+  zIndex?: number;
+}
+
+const DatasetLayer = ({ area, dataset, zIndex = 1 }: DatasetlayerProps) => {
+  const { data, isLoading, isError } = useQuery(
+    ["dataset", area, dataset],
+    () => fetchEntities(dataset.dataset, area),
+  );
+
+  if (isLoading || isError) {
+    return null;
+  }
+
+  return (
+    <MapLayer
+      features={data}
+      stroke={{ color: "#003078", width: 2 }}
+      fill={{ color: "rgba(0, 48, 120, 0.2)" }}
+      zIndex={zIndex}
+    />
+  );
+};
+
+export default DatasetLayer;

--- a/dluhc-component-library/src/components/maps/mapContainer.tsx
+++ b/dluhc-component-library/src/components/maps/mapContainer.tsx
@@ -1,4 +1,4 @@
-import { Map as OLMap } from "ol";
+import { Map as OLMap, View } from "ol";
 import {
   ComponentChildren,
   cloneElement,
@@ -21,7 +21,9 @@ const MapContainer = ({
   style,
   children,
 }: MapContainerProps) => {
-  const [map] = useState(new OLMap());
+  const [map] = useState(
+    new OLMap({ view: new View({ center: [0, 0], zoom: 0 }) }),
+  );
   const props = useMemo(
     () => ({ id, className, style }),
     [id, className, style],
@@ -35,8 +37,8 @@ const MapContainer = ({
   });
 
   return (
-    <MapProvider map={map} {...props}>
-      {childrenWithProps}
+    <MapProvider map={map}>
+      <div {...props}>{childrenWithProps}</div>
     </MapProvider>
   );
 };

--- a/dluhc-component-library/src/stories/DatasetSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/DatasetSelection.stories.tsx
@@ -1,0 +1,114 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
+import { fromExtent } from "ol/geom/Polygon";
+import { useState } from "preact/compat";
+import { ReactNode } from "react";
+import { fetchDatasetList } from "src/api/api";
+import { Dataset } from "src/api/types";
+import DatasetList from "src/components/datasets/DatasetList";
+import DatasetLayer from "src/components/maps/DatasetLayer";
+import BaseMap from "src/components/maps/baseMap";
+import MapContainer from "src/components/maps/mapContainer";
+import { useMap } from "src/contexts/mapContext";
+
+const queryClient = new QueryClient();
+
+interface MapComponentProps {
+  lat: number;
+  lng: number;
+  zoom: number;
+  selectedDatasets: Dataset[];
+}
+
+interface DatasetSelectionProps {
+  lat: number;
+  lng: number;
+  zoom: number;
+}
+
+const MapComponent = ({
+  lat,
+  lng,
+  zoom,
+  selectedDatasets,
+}: MapComponentProps) => {
+  const map = useMap();
+  const area = fromExtent(map.getView().calculateExtent(map.getSize()));
+  return (
+    <>
+      <BaseMap lat={lat} lng={lng} zoom={zoom} className="h-full" />
+      {selectedDatasets.map((dataset) => (
+        <DatasetLayer dataset={dataset} area={area} />
+      ))}
+    </>
+  );
+};
+
+const DatasetSelection = ({ lat, lng, zoom }: DatasetSelectionProps) => {
+  const { data: datasets, isLoading } = useQuery({
+    queryKey: ["datasets"],
+    queryFn: () => fetchDatasetList(),
+    select: (data) =>
+      data.datasets.sort((a, b) => a.name.localeCompare(b.name)),
+  });
+
+  const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>([]);
+
+  const onSelect = (dataset: Dataset) => {
+    const index = selectedDatasets.findIndex(
+      (d) => d.dataset === dataset.dataset,
+    );
+    if (index === -1) {
+      setSelectedDatasets([...selectedDatasets, dataset]);
+    } else {
+      setSelectedDatasets(selectedDatasets.filter((_, i) => i !== index));
+    }
+  };
+
+  return (
+    <div
+      className="grid grid-rows-1 grid-cols-8 h-full"
+      style={{ height: "500px" }}
+    >
+      <MapContainer style={{ height: "100%" }} className="col-span-5">
+        <MapComponent
+          lat={lat}
+          lng={lng}
+          zoom={zoom}
+          selectedDatasets={selectedDatasets}
+        />
+      </MapContainer>
+      <div className="col-span-3 grid">
+        <DatasetList
+          items={datasets || []}
+          selectedItems={selectedDatasets}
+          onSelect={onSelect}
+          isLoading={isLoading}
+        />
+      </div>
+    </div>
+  );
+};
+
+const queryWrapper = ({ lat, lng, zoom }: MapComponentProps) => (
+  <QueryClientProvider client={queryClient}>
+    {(<DatasetSelection lat={lat} lng={lng} zoom={zoom} />) as ReactNode}
+  </QueryClientProvider>
+);
+
+export default {
+  component: queryWrapper,
+  title: "Components/Map/Dataset Selection",
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    lat: 54.98,
+    lng: -1.62,
+    zoom: 12.9,
+  },
+};

--- a/dluhc-component-library/src/stories/DatasetSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/DatasetSelection.stories.tsx
@@ -41,7 +41,7 @@ const MapComponent = ({
     <>
       <BaseMap lat={lat} lng={lng} zoom={zoom} className="h-full" />
       {selectedDatasets.map((dataset) => (
-        <DatasetLayer dataset={dataset} area={area} />
+        <DatasetLayer dataset={dataset} area={area} key={dataset.dataset} />
       ))}
     </>
   );


### PR DESCRIPTION
This PR creates a storybook component that take selected datasets and renders the response GeoJSON on a map component:
![image](https://github.com/digital-land/plan-making/assets/47323438/cc4572b2-58fd-4115-a204-e10ca22395c5)

- Added React Query library
- Added API call to fetch an individual dataset
- Added loading state to `DatasetList` component
- Added `DatasetLayer` to fetch dataset GeoJSON and render it in a `MapLayer` component
- Added a storybook component for dataset selection

To be done in a future PR:
- Take colour from dataset object (if it exists) and use that instead of default blue colour.
- Find a more efficient way to get map bounds