### PR TITLE
DLUHC-204 apply dataset colours to layers on map

### DIFF
--- a/dluhc-component-library/src/api/types.ts
+++ b/dluhc-component-library/src/api/types.ts
@@ -11,5 +11,5 @@ export interface Dataset {
 
 export interface PaintOptions {
   colour: string;
-  opacity: number;
+  opacity?: number;
 }

--- a/dluhc-component-library/src/components/datasets/DatasetSelect.tsx
+++ b/dluhc-component-library/src/components/datasets/DatasetSelect.tsx
@@ -14,7 +14,7 @@ const DatasetSelect = ({ item, selected, onSelect }: DatasetSelectProps) => {
     <div key={item.dataset} className="flex items-center mb-4">
       <input
         id={id}
-        className="h-5 w-5 cursor-pointer"
+        className="h-5 w-5 flex-none cursor-pointer"
         type="checkbox"
         checked={selected}
         onChange={() => onSelect(item)}

--- a/dluhc-component-library/src/components/maps/DatasetLayer.tsx
+++ b/dluhc-component-library/src/components/maps/DatasetLayer.tsx
@@ -1,8 +1,11 @@
-import { Geometry } from "ol/geom";
-import { fetchEntities } from "src/api/api";
-import MapLayer from "./mapLayer";
 import { useQuery } from "@tanstack/react-query";
+import { Geometry } from "ol/geom";
+import { Options as FillOptions } from "ol/style/Fill";
+import { Options as StrokeOptions } from "ol/style/Stroke";
+import { useMemo } from "preact/compat";
+import { fetchEntities } from "src/api/api";
 import { Dataset } from "src/api/types";
+import MapLayer from "./mapLayer";
 
 interface DatasetlayerProps {
   area: Geometry;
@@ -20,13 +23,29 @@ const DatasetLayer = ({ area, dataset, zIndex = 1 }: DatasetlayerProps) => {
     return null;
   }
 
+  const stroke: StrokeOptions = useMemo(() => {
+    const color = dataset["paint-options"]
+      ? dataset["paint-options"].colour
+      : "#003078";
+    return { color, width: 2 };
+  }, [dataset]);
+
+  const fill: FillOptions = useMemo(() => {
+    const paintOptions = dataset["paint-options"];
+    if (!paintOptions) {
+      return { color: "rgba(0, 48, 120, 0.2)" };
+    }
+
+    const { colour, opacity } = paintOptions;
+    const red = parseInt(colour.slice(1, 3), 16);
+    const green = parseInt(colour.slice(3, 5), 16);
+    const blue = parseInt(colour.slice(5, 7), 16);
+
+    return { color: `rgb(${red}, ${green}, ${blue}, ${opacity || 0.2})` };
+  }, [dataset]);
+
   return (
-    <MapLayer
-      features={data}
-      stroke={{ color: "#003078", width: 2 }}
-      fill={{ color: "rgba(0, 48, 120, 0.2)" }}
-      zIndex={zIndex}
-    />
+    <MapLayer features={data} stroke={stroke} fill={fill} zIndex={zIndex} />
   );
 };
 


### PR DESCRIPTION
Each dataset object has an optional `paint-options` field. If this field is present calculates the stroke and fill for the polygon to be rendered. If it is not present will default to dark blue (matching https://www.planning.data.gov.uk/map/).

The below map shows:
- Article 4 direction area (default dark blue)
- Historic parks and gardens (green)
- Scheduled monument (light blue)
 
![image](https://github.com/digital-land/plan-making/assets/47323438/d12d0459-573a-4ece-a8cf-f0c3d645ff96)

