### PR TITLE
DLUHC-175 Add form validation

### DIFF
--- a/dluhc-component-library/package-lock.json
+++ b/dluhc-component-library/package-lock.json
@@ -12,7 +12,8 @@
         "@tanstack/react-table": "^8.9.3",
         "csvtojson": "^2.0.10",
         "ol": "^7.5.0",
-        "preact": "^10.16.0"
+        "preact": "^10.16.0",
+        "yup": "^1.2.0"
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.5.0",
@@ -10986,6 +10987,11 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
+    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
@@ -12522,6 +12528,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -12570,6 +12581,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -12601,7 +12617,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -13346,6 +13361,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.2.0.tgz",
+      "integrity": "sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     }
   }

--- a/dluhc-component-library/package.json
+++ b/dluhc-component-library/package.json
@@ -17,7 +17,8 @@
     "@tanstack/react-table": "^8.9.3",
     "csvtojson": "^2.0.10",
     "ol": "^7.5.0",
-    "preact": "^10.16.0"
+    "preact": "^10.16.0",
+    "yup": "^1.2.0"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.5.0",

--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -25,7 +25,7 @@ const createValidationSchema = (
       break;
   }
 
-  if (formSchema.required.includes(key)) {
+  if (validationShape && formSchema.required.includes(key)) {
     validationShape = validationShape.required();
   }
 

--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from "preact/hooks";
 import { loadJson } from "../../utils";
 import DynamicForm from "./components/DynamicForm";
 import { FormState, FormValue, SiteSelectionFormSchema } from "./types";
-import { ObjectShape, ValidationError, object, string } from "yup";
+import { StringSchema, ValidationError, object, string } from "yup";
 import "./SiteSelectionForm.css";
 import FormPage from "./components/FormPage";
 
@@ -15,7 +15,7 @@ const createValidationSchema = (
   key: string,
   formSchema: SiteSelectionFormSchema,
 ) => {
-  let validationShape: any;
+  let validationShape: StringSchema;
 
   const property = formSchema.properties[key];
 
@@ -29,7 +29,7 @@ const createValidationSchema = (
     validationShape = validationShape.required(`This field is required.`);
   }
 
-  return object({ [key]: validationShape } as ObjectShape);
+  return object({ [key]: validationShape });
 };
 
 const SiteSelectionForm = ({ filepath, data }: SiteSelectionForm) => {

--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -26,7 +26,7 @@ const createValidationSchema = (
   }
 
   if (validationShape && formSchema.required.includes(key)) {
-    validationShape = validationShape.required();
+    validationShape = validationShape.required(`This field is required.`);
   }
 
   return object({ [key]: validationShape } as ObjectShape);

--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -71,6 +71,8 @@ const DynamicForm = ({
       );
 
       break;
+
+    // TODO: parse number to int in input field
     case InputType.NumberInput:
       questionInputComponent = (
         <Input

--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -22,11 +22,17 @@ enum InputType {
 
 const getInputType = (formPageSchema: FormPageSchema) => {
   if (formPageSchema.type === "string") {
-    return formPageSchema.enum ? InputType.MultiSelect : InputType.TextInput;
+    return InputType.TextInput;
   }
+
   if (formPageSchema.type === "number") {
     return InputType.NumberInput;
   }
+
+  if (formPageSchema.type === "array") {
+    return InputType.MultiSelect;
+  }
+
   if (formPageSchema.type === "radio") {
     return InputType.RadioInput;
   }

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -1,4 +1,5 @@
 export interface SiteSelectionFormSchema {
+  required: Array<string>;
   properties: Record<string, FormPageSchema>;
 }
 

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -17,7 +17,8 @@ export const Default = {
           title: "Your name",
         },
         siteUse: {
-          type: "string",
+          type: "array",
+          items: { type: "string" },
           title:
             "What use or uses do you think should be considered for this site?",
           subtitle: "You can choose as many uses as you'd like.",

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -12,6 +12,10 @@ export const Default = {
       required: ["siteUse", "relationshipTo", "address", "name"],
       type: "object",
       properties: {
+        name: {
+          type: "string",
+          title: "Your name",
+        },
         siteUse: {
           type: "string",
           title:
@@ -52,10 +56,6 @@ export const Default = {
         address: {
           type: "string",
           title: "Please provide the fullest postal address you can",
-        },
-        name: {
-          type: "string",
-          title: "Your name",
         },
         age: {
           type: "number",


### PR DESCRIPTION
This PR adds  basic validation for the form using the `yup` package. Currently only validates `string` text input boxes, and only displays one error.

![image](https://github.com/digital-land/plan-making/assets/60654572/7b85c5bf-1925-442a-a227-31daa9fdf4c7)
