### PR TITLE
DLUCH-175 validate numbers

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -2,7 +2,14 @@ import { useState, useEffect, useMemo } from "preact/hooks";
 import { loadJson } from "../../utils";
 import DynamicForm from "./components/DynamicForm";
 import { FormState, FormValue, SiteSelectionFormSchema } from "./types";
-import { StringSchema, ValidationError, object, string } from "yup";
+import {
+  NumberSchema,
+  StringSchema,
+  ValidationError,
+  number,
+  object,
+  string,
+} from "yup";
 import "./SiteSelectionForm.css";
 import FormPage from "./components/FormPage";
 
@@ -15,13 +22,16 @@ const createValidationSchema = (
   key: string,
   formSchema: SiteSelectionFormSchema,
 ) => {
-  let validationShape: StringSchema;
+  let validationShape: StringSchema | NumberSchema;
 
   const property = formSchema.properties[key];
 
   switch (property.type) {
     case "string":
       validationShape = string();
+      break;
+    case "number":
+      validationShape = number();
       break;
   }
 

--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -78,12 +78,11 @@ const DynamicForm = ({
 
       break;
 
-    // TODO: parse number to int in input field
     case InputType.NumberInput:
       questionInputComponent = (
         <Input
           type={formPageSchema.type}
-          value={(value as number) ?? 0}
+          value={value as number}
           step={formPageSchema.step}
           min={formPageSchema.min}
           max={formPageSchema.max}

--- a/dluhc-component-library/src/components/siteSelectionForm/components/Input.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/Input.tsx
@@ -15,6 +15,16 @@ const Input = <T extends number | string>({
   max,
   onChange,
 }: InputProps<T>) => {
+  const handleChange = (value: string) => {
+    let parsedValue: number | string = value;
+
+    if (type == "number") {
+      parsedValue = Number(value);
+    }
+
+    onChange(parsedValue as T);
+  };
+
   const InputBox = (
     <div className="flex items-center mb-4">
       <label className="font-semibold flex">
@@ -22,7 +32,7 @@ const Input = <T extends number | string>({
           type={type}
           class="text mr-2"
           value={value}
-          onChange={(event) => onChange(event.currentTarget.value as T)}
+          onChange={(event) => handleChange(event.currentTarget.value)}
           step={step}
           min={min}
           max={max}

--- a/dluhc-component-library/src/components/siteSelectionForm/components/Input.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/Input.tsx
@@ -16,13 +16,7 @@ const Input = <T extends number | string>({
   onChange,
 }: InputProps<T>) => {
   const handleChange = (value: string) => {
-    let parsedValue: number | string = value;
-
-    if (type == "number") {
-      parsedValue = Number(value);
-    }
-
-    onChange(parsedValue as T);
+    onChange((type === "number" ? parseFloat(value) : value) as T);
   };
 
   const InputBox = (

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -3,7 +3,7 @@ export interface SiteSelectionFormSchema {
   properties: Record<string, FormPageSchema>;
 }
 
-export type QuestionType = "string";
+export type QuestionType = "string" | "number";
 
 export interface FormPageSchema {
   type: QuestionType;

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -9,7 +9,7 @@ export default {
 export const Default = {
   args: {
     data: {
-      required: ["siteUse", "relationshipTo", "address", "name"],
+      required: ["siteUse", "relationshipTo", "address", "name", "age"],
       type: "object",
       properties: {
         name: {
@@ -54,16 +54,16 @@ export const Default = {
           title: "Is this a Brownfield Site? ",
           enum: ["Yes", "No"],
         },
-        address: {
-          type: "string",
-          title: "Please provide the fullest postal address you can",
-        },
         age: {
           type: "number",
           title: "Age in years",
           step: 1,
           min: 18,
           max: 35,
+        },
+        address: {
+          type: "string",
+          title: "Please provide the fullest postal address you can",
         },
       },
     },


### PR DESCRIPTION
This PR fixes the number parsing where previously numbers were being stored in the state as strings, and validates that a number has been put in if it is a required field 


![image](https://github.com/digital-land/plan-making/assets/60654572/02cb8fbb-8e5f-44d2-8733-5f0004db112f)
