### PR TITLE
DLUHC-175 Handle object type

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/components/Input.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/Input.tsx
@@ -16,11 +16,11 @@ const Input = <T extends number | string>({
   onChange,
 }: InputProps<T>) => {
   const InputBox = (
-    <div className="flex items-center mb-4">
+    <div className="flex items-center my-8">
       <label className="font-semibold flex">
         <input
           type={type}
-          class="text mr-2"
+          class="text mr-2 border-2 border-black py-1 px-2"
           value={value}
           onChange={(event) => onChange(event.currentTarget.value as T)}
           step={step}

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -1,9 +1,4 @@
-export interface SiteSelectionFormSchema {
-  required: Array<string>;
-  properties: Record<string, FormPageSchema>;
-}
-
-export type QuestionType = "string";
+export type QuestionType = "string" | "object";
 
 export interface FormPageSchema {
   type: QuestionType;
@@ -13,6 +8,9 @@ export interface FormPageSchema {
   step?: string;
   min?: string;
   max?: string;
+  required?: ReadonlyArray<string>;
+  properties?: Record<string, FormPageSchema>;
+  dependencies?: Record<string, ReadonlyArray<string>>;
 }
 
 export type FormValue = string | number | boolean | Record<string, boolean>;

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -69,3 +69,31 @@ export const Default = {
     },
   },
 };
+
+export const ConditionalPage = {
+  args: {
+    data: {
+      required: [],
+      type: "object",
+      properties: {
+        groupedExample: {
+          type: "object",
+          properties: {
+            parentQuestion: {
+              type: "string",
+              title: "Parent question",
+              subtitle: "Adding a value here will add another question",
+            },
+            addedQuestion: {
+              type: "string",
+              title: "Optional question ",
+            },
+          },
+          dependencies: {
+            parentQuestion: ["addedQuestion"],
+          },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
This is a step towards handling conditional properties (questions).

The code recursively looks over the entire schema and flattens all the nested properties into one property object for the form to iterate over.

The potential problem with this is when it comes to validating the form values back against the schema since they will have lost the indentation. This can be fixed in the future as that is currently not a requirement.