### PR TITLE
Add form dependency logic

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -41,11 +41,45 @@ const createValidationSchema = (key: string, formSchema: FormPageSchema) => {
   return object({ [key]: validationShape } as ObjectShape);
 };
 
-const createFlatFormSchema = (formSchema: FormPageSchema) => {
-  const newSchema: FormPageSchema = {
+const addChildProperties = (
+  baseFormSchema: FormPageSchema,
+  newFormSchema: FormPageSchema,
+  formValues: FormState,
+) => {
+  let newProperties: Record<string, FormPageSchema> = {};
+  let newRequired: ReadonlyArray<string> = [];
+
+  const childSchema = createFlatFormSchema(newFormSchema, formValues);
+
+  newProperties = {
+    ...baseFormSchema.properties,
+    ...childSchema.properties,
+  };
+
+  if (childSchema.required?.length) {
+    newRequired = [
+      ...(baseFormSchema.required as string[]),
+      ...childSchema.required,
+    ];
+  }
+
+  const updatedFormSchema: FormPageSchema = {
+    ...baseFormSchema,
+    properties: newProperties,
+    required: newRequired,
+  };
+
+  return updatedFormSchema;
+};
+
+const createFlatFormSchema = (
+  formSchema: FormPageSchema,
+  formValues: FormState,
+) => {
+  let newSchema: FormPageSchema = {
     type: formSchema.type,
     title: formSchema.title,
-    dependencies: formSchema.dependencies,
+    dependencies: {},
     properties: {},
     required: [],
   };
@@ -62,26 +96,28 @@ const createFlatFormSchema = (formSchema: FormPageSchema) => {
     }
 
     if (formSchema.properties?.[propertyKey]?.type === "object") {
-      const childSchema = createFlatFormSchema(
+      newSchema = addChildProperties(
+        newSchema,
         formSchema.properties[propertyKey],
+        formValues,
       );
-
-      newSchema.properties = {
-        ...newSchema.properties,
-        ...childSchema.properties,
-      };
-
-      if (childSchema.required?.length) {
-        newSchema.required = [
-          ...(newSchema.required as string[]),
-          ...childSchema.required,
-        ];
-      }
     } else {
       newSchema.properties = {
         ...newSchema.properties,
         [propertyKey]: formSchema.properties[propertyKey],
       };
+    }
+
+    if (
+      formSchema.dependencies &&
+      formSchema.dependencies[propertyKey] &&
+      formValues[propertyKey]
+    ) {
+      newSchema = addChildProperties(
+        newSchema,
+        formSchema.dependencies[propertyKey],
+        formValues,
+      );
     }
   });
 
@@ -112,8 +148,8 @@ const SiteSelectionForm = ({ filepath, data }: SiteSelectionForm) => {
   }, [setBaseSchema, filepath, data]);
 
   const formSchema: FormPageSchema | null = useMemo(
-    () => baseSchema && createFlatFormSchema(baseSchema),
-    [baseSchema],
+    () => baseSchema && createFlatFormSchema(baseSchema, formData),
+    [baseSchema, formData],
   );
 
   if (!formSchema || !formSchema?.properties) {

--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -46,15 +46,14 @@ const addChildProperties = (
   newFormSchema: FormPageSchema,
   formValues: FormState,
 ) => {
-  let newProperties: Record<string, FormPageSchema> = {};
-  let newRequired: ReadonlyArray<string> = [];
-
   const childSchema = createFlatFormSchema(newFormSchema, formValues);
 
-  newProperties = {
+  const newProperties: Record<string, FormPageSchema> = {
     ...baseFormSchema.properties,
     ...childSchema.properties,
   };
+
+  let newRequired: ReadonlyArray<string> = [];
 
   if (childSchema.required?.length) {
     newRequired = [

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -10,7 +10,7 @@ export interface FormPageSchema {
   max?: string;
   required?: ReadonlyArray<string>;
   properties?: Record<string, FormPageSchema>;
-  dependencies?: Record<string, ReadonlyArray<string>>;
+  dependencies?: Record<string, FormPageSchema>;
 }
 
 export type FormValue = string | number | boolean | Record<string, boolean>;

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -82,15 +82,27 @@ export const ConditionalPage = {
             parentQuestion: {
               type: "string",
               title: "Parent question",
-              subtitle: "Adding a value here will add another question",
+              subtitle: 'Adding a value here will add an "Additional question"',
             },
-            addedQuestion: {
+            unrelatedQuestion: {
               type: "string",
-              title: "Optional question ",
+              title: "Unrelated question",
+              subtitle:
+                "This question should come after the Parent and Additional questions",
             },
           },
           dependencies: {
-            parentQuestion: ["addedQuestion"],
+            parentQuestion: {
+              properties: {
+                addedQuestion: {
+                  type: "string",
+                  title: "Additional question",
+                  subtitle:
+                    'This question should only be asked if you answered the "Parent questions"',
+                },
+              },
+              required: ["addedQuestion"],
+            },
           },
         },
       },


### PR DESCRIPTION
Adds the ability for our site identification form to check the dependencies and add additional properties if there is a value present (not specific values yet).

_This is hard to show in screenshots so i recommend testing out the branch_

If you skip the "Parent question", you should go straight to the "Unrelated question".

If you answer the "Parent question", an "Additional question" should be inserted before the "Unrelated question" and be required.