### PR TITLE
DLUHC-175 Add boolean validation

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect, useMemo } from "preact/hooks";
 import {
-  NumberSchema,
   ObjectShape,
-  StringSchema,
   ValidationError,
+  boolean,
   number,
   object,
   string,
@@ -11,7 +10,7 @@ import {
 import { loadJson } from "src/utils";
 import DynamicForm from "./components/DynamicForm";
 import FormPage from "./components/FormPage";
-import { FormState, FormValue, FormPageSchema } from "./types";
+import { FormState, FormValue, FormPageSchema, ValidationShape } from "./types";
 
 import "./SiteSelectionForm.css";
 
@@ -21,7 +20,7 @@ interface SiteSelectionForm {
 }
 
 const createValidationSchema = (key: string, formSchema: FormPageSchema) => {
-  let validationShape: StringSchema | NumberSchema | null = null;
+  let validationShape: ValidationShape | null = null;
 
   const property = formSchema.properties?.[key];
 
@@ -31,6 +30,9 @@ const createValidationSchema = (key: string, formSchema: FormPageSchema) => {
       break;
     case "number":
       validationShape = number();
+      break;
+    case "boolean":
+      validationShape = boolean();
       break;
   }
 

--- a/dluhc-component-library/src/components/siteSelectionForm/components/BooleanInput.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/BooleanInput.tsx
@@ -1,0 +1,26 @@
+interface BooleanInputProps {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+const BooleanInput = ({ value, onChange }: BooleanInputProps) => {
+  const checkboxComponent = () => {
+    let isChecked = value;
+    return (
+      <div className="flex items-center">
+        <label className="font-semibold flex">
+          <input
+            type="checkbox"
+            class="checkbox mr-2"
+            checked={isChecked}
+            onClick={() => onChange(!isChecked)}
+          />
+        </label>
+      </div>
+    );
+  };
+
+  return <div>{checkboxComponent()}</div>;
+};
+
+export default BooleanInput;

--- a/dluhc-component-library/src/components/siteSelectionForm/components/BooleanInput.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/BooleanInput.tsx
@@ -4,23 +4,18 @@ interface BooleanInputProps {
 }
 
 const BooleanInput = ({ value, onChange }: BooleanInputProps) => {
-  const checkboxComponent = () => {
-    let isChecked = value;
-    return (
-      <div className="flex items-center">
-        <label className="font-semibold flex">
-          <input
-            type="checkbox"
-            class="checkbox mr-2"
-            checked={isChecked}
-            onClick={() => onChange(!isChecked)}
-          />
-        </label>
-      </div>
-    );
-  };
-
-  return <div>{checkboxComponent()}</div>;
+  return (
+    <div className="flex items-center">
+      <label className="font-semibold flex">
+        <input
+          type="checkbox"
+          class="checkbox mr-2"
+          checked={value}
+          onClick={() => onChange(!value)}
+        />
+      </label>
+    </div>
+  );
 };
 
 export default BooleanInput;

--- a/dluhc-component-library/src/components/siteSelectionForm/components/Checkbox.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/Checkbox.tsx
@@ -1,9 +1,9 @@
-interface BooleanInputProps {
+interface CheckboxInputProps {
   value: boolean;
   onChange: (value: boolean) => void;
 }
 
-const BooleanInput = ({ value, onChange }: BooleanInputProps) => {
+const Checkbox = ({ value, onChange }: CheckboxInputProps) => {
   return (
     <div className="flex items-center">
       <label className="font-semibold flex">
@@ -18,4 +18,4 @@ const BooleanInput = ({ value, onChange }: BooleanInputProps) => {
   );
 };
 
-export default BooleanInput;
+export default Checkbox;

--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -4,7 +4,7 @@ import MultiSelect from "./MultiSelect";
 import { JSXInternal } from "node_modules/preact/src/jsx";
 import Input from "./Input";
 import RadioButtons from "./RadioButtons";
-import BooleanInput from "./BooleanInput";
+import BooleanInput from "./Checkbox";
 
 interface DynamicFormProps {
   id: string;

--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -4,6 +4,7 @@ import MultiSelect from "./MultiSelect";
 import { JSXInternal } from "node_modules/preact/src/jsx";
 import Input from "./Input";
 import RadioButtons from "./RadioButtons";
+import BooleanInput from "./BooleanInput";
 
 interface DynamicFormProps {
   id: string;
@@ -17,6 +18,7 @@ enum InputType {
   NumberInput,
   RadioInput,
   MultiSelect,
+  BooleanInput,
   None,
 }
 
@@ -35,6 +37,10 @@ const getInputType = (formPageSchema: FormPageSchema) => {
 
   if (formPageSchema.type === "radio") {
     return InputType.RadioInput;
+  }
+
+  if (formPageSchema.type == "boolean") {
+    return InputType.BooleanInput;
   }
 
   return InputType.None;
@@ -98,6 +104,15 @@ const DynamicForm = ({
           name={formPageSchema.title}
           options={formPageSchema.enum as ReadonlyArray<string>}
           value={value as String}
+          onChange={handleFormValueChange}
+        />
+      );
+      break;
+
+    case InputType.BooleanInput:
+      questionInputComponent = (
+        <BooleanInput
+          value={value as boolean}
           onChange={handleFormValueChange}
         />
       );

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -1,3 +1,5 @@
+import { StringSchema, NumberSchema, BooleanSchema } from "yup";
+
 export type QuestionType =
   | "string"
   | "number"
@@ -22,3 +24,5 @@ export interface FormPageSchema {
 export type FormValue = string | number | boolean | Record<string, boolean>;
 
 export type FormState = Record<string, FormValue>;
+
+export type ValidationShape = StringSchema | NumberSchema | BooleanSchema;

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -1,4 +1,10 @@
-export type QuestionType = "string" | "number" | "object";
+export type QuestionType =
+  | "string"
+  | "number"
+  | "array"
+  | "object"
+  | "radio"
+  | "boolean";
 
 export interface FormPageSchema {
   type: QuestionType;

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -9,7 +9,14 @@ export default {
 export const Default = {
   args: {
     data: {
-      required: ["siteUse", "relationshipTo", "address", "name", "age"],
+      required: [
+        "siteUse",
+        "relationshipTo",
+        "address",
+        "name",
+        "age",
+        "consent",
+      ],
       type: "object",
       properties: {
         name: {

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -16,6 +16,10 @@ export const Default = {
           type: "string",
           title: "Your name",
         },
+        consent: {
+          type: "boolean",
+          title: "I confirm consent for my data to be processed",
+        },
         siteUse: {
           type: "array",
           items: { type: "string" },


### PR DESCRIPTION
Adds a boolean input type and validates that it has been checked. 

Uses a simple checkbox for the boolean input and as such, after it's been checked it's either `true` or `false` in the state so will pass validation if the box isn't checked. 

Have left the validation as-is - could force it to want a `true` or remove from state if false but this is the easiest way to do an example 

![image](https://github.com/digital-land/plan-making/assets/60654572/893d259e-488a-4066-9acf-6f66fa43c04c)
