### PR TITLE
DLUHC-264 add boundary value input

### DIFF
--- a/dluhc-component-library/src/components/maps/DrawingLayer.tsx
+++ b/dluhc-component-library/src/components/maps/DrawingLayer.tsx
@@ -6,6 +6,7 @@ import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import { useEffect, useRef } from "preact/compat";
 import { useMap } from "src/contexts/mapContext";
+import { Polygon as Boundary } from "./types";
 
 interface DrawingLayerProps {
   zIndex?: number;
@@ -14,8 +15,8 @@ interface DrawingLayerProps {
   strokeWidth?: number;
   circleRadius?: number;
   circleFillColor?: string;
-  value?: number[][][];
-  onChange?: (boundary: number[][][]) => void;
+  value?: Boundary;
+  onChange?: (boundary: Boundary) => void;
 }
 
 const DrawingLayer = ({
@@ -60,7 +61,9 @@ const DrawingLayer = ({
   useEffect(() => {
     source.current.clear(); // for now, only allow 1 boundary to be drawn
     if (value) {
-      source.current.addFeature(new Feature({ geometry: new Polygon(value) }));
+      source.current.addFeature(
+        new Feature({ geometry: new Polygon(value as number[][][]) }),
+      );
     }
   }, [value, source]);
 

--- a/dluhc-component-library/src/components/maps/DrawingLayer.tsx
+++ b/dluhc-component-library/src/components/maps/DrawingLayer.tsx
@@ -6,7 +6,7 @@ import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import { useEffect, useRef } from "preact/compat";
 import { useMap } from "src/contexts/mapContext";
-import { Polygon as Boundary } from "./types";
+import { Boundary } from "./types";
 
 interface DrawingLayerProps {
   zIndex?: number;

--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -14,8 +14,8 @@ interface MapComponentProps {
   id?: string;
   className?: string;
   style?: CSSProperties;
-  value?: string;
-  onChange?: (boundary: string) => void;
+  value?: number[][][];
+  onChange?: (boundary: number[][][]) => void;
 }
 
 interface BaseMapProps {

--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -4,6 +4,7 @@ import DatasetControl from "./DatasetControl";
 import DatasetLayers from "./DatasetLayers";
 import DrawingLayer from "./DrawingLayer";
 import MapContainer from "./MapContainer";
+import { Polygon as Boundary } from "./types";
 
 import "./MapComponent.css";
 
@@ -14,8 +15,8 @@ interface MapComponentProps {
   id?: string;
   className?: string;
   style?: CSSProperties;
-  value?: number[][][];
-  onChange?: (boundary: number[][][]) => void;
+  value?: Boundary;
+  onChange?: (boundary: Boundary) => void;
 }
 
 interface BaseMapProps {

--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -1,4 +1,3 @@
-import Polygon from "ol/geom/Polygon";
 import { CSSProperties, useState } from "preact/compat";
 import BaseMap from "./BaseMap";
 import DatasetControl from "./DatasetControl";
@@ -15,7 +14,8 @@ interface MapComponentProps {
   id?: string;
   className?: string;
   style?: CSSProperties;
-  onChange?: (boundary: Polygon) => void;
+  value?: string;
+  onChange?: (boundary: string) => void;
 }
 
 interface BaseMapProps {
@@ -53,6 +53,7 @@ const MapComponent = ({
   className = "map-container",
   style = { height: "700px", width: "100%" },
   showDatasets = true,
+  value,
   onChange,
   baseMapProps,
   drawingMapProps,
@@ -101,6 +102,7 @@ const MapComponent = ({
           strokeWidth={customDrawingProperties.strokeWidth}
           circleRadius={customDrawingProperties.circleRadius}
           circleFillColor={customDrawingProperties.circleFillColor}
+          value={value}
           onChange={onChange}
         />
       )}

--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -4,7 +4,7 @@ import DatasetControl from "./DatasetControl";
 import DatasetLayers from "./DatasetLayers";
 import DrawingLayer from "./DrawingLayer";
 import MapContainer from "./MapContainer";
-import { Polygon as Boundary } from "./types";
+import { Boundary } from "./types";
 
 import "./MapComponent.css";
 

--- a/dluhc-component-library/src/components/maps/types.ts
+++ b/dluhc-component-library/src/components/maps/types.ts
@@ -1,0 +1,5 @@
+export type Coordinate = ReadonlyArray<number>;
+
+export type LinearRing = ReadonlyArray<Coordinate>;
+
+export type Polygon = ReadonlyArray<LinearRing>;

--- a/dluhc-component-library/src/components/maps/types.ts
+++ b/dluhc-component-library/src/components/maps/types.ts
@@ -2,4 +2,4 @@ export type Coordinate = ReadonlyArray<number>;
 
 export type LinearRing = ReadonlyArray<Coordinate>;
 
-export type Polygon = ReadonlyArray<LinearRing>;
+export type Boundary = ReadonlyArray<LinearRing>;

--- a/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
+++ b/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
@@ -26,7 +26,7 @@ interface DrawingMapProps {
 const queryClient = new QueryClient();
 
 const MapInput = ({ baseMapProps, drawingMapProps }: MapComponentProps) => {
-  const [boundary, setBoundary] = useState<string>();
+  const [boundary, setBoundary] = useState<number[][][]>();
   return (
     <>
       <QueryClientProvider client={queryClient}>
@@ -37,7 +37,7 @@ const MapInput = ({ baseMapProps, drawingMapProps }: MapComponentProps) => {
               drawingMapProps={drawingMapProps}
               showDatasets={false}
               value={boundary}
-              onChange={(boundary) => setBoundary(boundary)}
+              onChange={setBoundary}
             />
           ) as ReactNode
         }

--- a/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
+++ b/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "preact/compat";
 import { ReactNode } from "react";
 import MapComponent from "src/components/maps/MapComponent";
 
@@ -25,18 +26,23 @@ interface DrawingMapProps {
 const queryClient = new QueryClient();
 
 const MapInput = ({ baseMapProps, drawingMapProps }: MapComponentProps) => {
+  const [boundary, setBoundary] = useState<string>();
   return (
-    <QueryClientProvider client={queryClient}>
-      {
-        (
-          <MapComponent
-            baseMapProps={baseMapProps}
-            drawingMapProps={drawingMapProps}
-            showDatasets={false}
-          />
-        ) as ReactNode
-      }
-    </QueryClientProvider>
+    <>
+      <QueryClientProvider client={queryClient}>
+        {
+          (
+            <MapComponent
+              baseMapProps={baseMapProps}
+              drawingMapProps={drawingMapProps}
+              showDatasets={false}
+              value={boundary}
+              onChange={(boundary) => setBoundary(boundary)}
+            />
+          ) as ReactNode
+        }
+      </QueryClientProvider>
+    </>
   );
 };
 

--- a/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
+++ b/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "preact/compat";
 import { ReactNode } from "react";
 import MapComponent from "src/components/maps/MapComponent";
-import { Polygon as Boundary } from "src/components/maps/types";
+import { Boundary } from "src/components/maps/types";
 
 interface MapComponentProps {
   baseMapProps: BaseMapProps;

--- a/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
+++ b/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "preact/compat";
 import { ReactNode } from "react";
 import MapComponent from "src/components/maps/MapComponent";
+import { Polygon as Boundary } from "src/components/maps/types";
 
 interface MapComponentProps {
   baseMapProps: BaseMapProps;
@@ -26,7 +27,7 @@ interface DrawingMapProps {
 const queryClient = new QueryClient();
 
 const MapInput = ({ baseMapProps, drawingMapProps }: MapComponentProps) => {
-  const [boundary, setBoundary] = useState<number[][][]>();
+  const [boundary, setBoundary] = useState<Boundary>();
   return (
     <>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Adds the drawable boundary as an input to the `MapComponent` effectively turning the map into a controlled input for boundary drawing. The data format is a `number[][][]` representation of the polygon. Currently only supports drawing 1 boundary, if another boundary is drawn the old one will get deleted.

- Added value as input to `MapComponent` and `Drawinglayer`
- Updated output return type to be `number[][][]`
- Removed the `div` ref from drawing layer. It's wasn't needed since the drawing layer is always a child of the map container which has a map defined.
- Added types for `Coordinate`, `LinearRing` and `Polygon`

Boundary editing will be added in a future PR.