### PR TITLE
DLUHC-176 Add map page to dynamic form

### DIFF
--- a/dluhc-component-library/src/components/accordianDropdown/AccordionDropdown.tsx
+++ b/dluhc-component-library/src/components/accordianDropdown/AccordionDropdown.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { IndicationArrow } from "../inlinesvgs/IndicationArrow";
 import { ComponentChildren } from "preact";
+import { useState } from "preact/hooks";
+import { IndicationArrow } from "../inlinesvgs/IndicationArrow";
 
 interface AccordionDropdownProps {
   text: string;

--- a/dluhc-component-library/src/components/accordianDropdown/AccordionDropdown.tsx
+++ b/dluhc-component-library/src/components/accordianDropdown/AccordionDropdown.tsx
@@ -3,10 +3,11 @@ import { IndicationArrow } from "../inlinesvgs/IndicationArrow";
 import { ComponentChildren } from "preact";
 
 interface AccordionDropdownProps {
+  text: string;
   children?: ComponentChildren;
 }
 
-const AccordionDropdown = ({ children }: AccordionDropdownProps) => {
+const AccordionDropdown = ({ text, children }: AccordionDropdownProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleDropdownClicked = () => {
@@ -23,7 +24,7 @@ const AccordionDropdown = ({ children }: AccordionDropdownProps) => {
       <IndicationArrow
         className={`h-3 w-3 transition-all inline-block ${rotationClass}`}
       />
-      <span className="text-blue-400 underline pl-2">More information</span>
+      <span className="text-blue-400 underline pl-2">{text}</span>
       {isExpanded && <div class="border-l-4 p-4 m-1">{children}</div>}
     </div>
   );

--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -1,3 +1,5 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
 import { useState, useEffect, useMemo } from "preact/hooks";
 import {
   ObjectShape,
@@ -13,8 +15,6 @@ import FormPage from "./components/FormPage";
 import { FormState, FormValue, FormPageSchema, ValidationShape } from "./types";
 
 import "./SiteSelectionForm.css";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
 
 interface SiteSelectionForm {
   filepath?: string;

--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -13,6 +13,8 @@ import FormPage from "./components/FormPage";
 import { FormState, FormValue, FormPageSchema, ValidationShape } from "./types";
 
 import "./SiteSelectionForm.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
 
 interface SiteSelectionForm {
   filepath?: string;
@@ -125,6 +127,8 @@ const createFlatFormSchema = (
   return newSchema;
 };
 
+const queryClient = new QueryClient();
+
 const SiteSelectionForm = ({ filepath, data }: SiteSelectionForm) => {
   const [baseSchema, setBaseSchema] = useState<FormPageSchema | null>(null);
 
@@ -208,20 +212,28 @@ const SiteSelectionForm = ({ filepath, data }: SiteSelectionForm) => {
   };
 
   return (
-    <FormPage
-      title={formSchema.properties[currentPageId].title}
-      subtitle={formSchema.properties[currentPageId].subtitle}
-      onBackClicked={handleBackClicked}
-      onContinueClicked={handleContinueClicked}
-    >
-      <DynamicForm
-        id={currentPageId}
-        formPageSchema={formSchema.properties[currentPageId]}
-        value={formData[currentPageId]}
-        onFormValueChange={handleFormValueChange}
-      />
-      {!!errors[currentPageId]?.length && <div>{errors[currentPageId][0]}</div>}
-    </FormPage>
+    <QueryClientProvider client={queryClient}>
+      {
+        (
+          <FormPage
+            title={formSchema.properties[currentPageId].title}
+            subtitle={formSchema.properties[currentPageId].subtitle}
+            onBackClicked={handleBackClicked}
+            onContinueClicked={handleContinueClicked}
+          >
+            <DynamicForm
+              id={currentPageId}
+              formPageSchema={formSchema.properties[currentPageId]}
+              value={formData[currentPageId]}
+              onFormValueChange={handleFormValueChange}
+            />
+            {!!errors[currentPageId]?.length && (
+              <div>{errors[currentPageId][0]}</div>
+            )}
+          </FormPage>
+        ) as ReactNode
+      }
+    </QueryClientProvider>
   );
 };
 

--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "preact/hooks";
-import { FormPageSchema, FormValue } from "../types";
+import { FormPageSchema, FormValue, QuestionType } from "../types";
 import MultiSelect from "./MultiSelect";
 import { JSXInternal } from "node_modules/preact/src/jsx";
 import Input from "./Input";
 import RadioButtons from "./RadioButtons";
 import BooleanInput from "./Checkbox";
+import MapPage from "./MapPage";
 
 interface DynamicFormProps {
   id: string;
@@ -19,31 +20,18 @@ enum InputType {
   RadioInput,
   MultiSelect,
   BooleanInput,
+  Map,
   None,
 }
 
-const getInputType = (formPageSchema: FormPageSchema) => {
-  if (formPageSchema.type === "string") {
-    return InputType.TextInput;
-  }
-
-  if (formPageSchema.type === "number") {
-    return InputType.NumberInput;
-  }
-
-  if (formPageSchema.type === "array") {
-    return InputType.MultiSelect;
-  }
-
-  if (formPageSchema.type === "radio") {
-    return InputType.RadioInput;
-  }
-
-  if (formPageSchema.type == "boolean") {
-    return InputType.BooleanInput;
-  }
-
-  return InputType.None;
+const InputTypeMap: Record<QuestionType, InputType> = {
+  string: InputType.TextInput,
+  number: InputType.NumberInput,
+  array: InputType.MultiSelect,
+  radio: InputType.RadioInput,
+  boolean: InputType.BooleanInput,
+  map: InputType.Map,
+  object: InputType.None,
 };
 
 const DynamicForm = ({
@@ -54,16 +42,11 @@ const DynamicForm = ({
 }: DynamicFormProps) => {
   let questionInputComponent: JSXInternal.Element | null = null;
 
-  const inputType = useMemo(
-    () => getInputType(formPageSchema),
-    [formPageSchema],
-  );
-
   const handleFormValueChange = (newValue: FormValue) => {
     onFormValueChange(id, newValue);
   };
 
-  switch (inputType) {
+  switch (InputTypeMap[formPageSchema.type]) {
     case InputType.MultiSelect:
       questionInputComponent = (
         <MultiSelect
@@ -81,7 +64,6 @@ const DynamicForm = ({
           onChange={handleFormValueChange}
         />
       );
-
       break;
 
     case InputType.NumberInput:
@@ -95,7 +77,6 @@ const DynamicForm = ({
           onChange={handleFormValueChange}
         />
       );
-
       break;
 
     case InputType.RadioInput:
@@ -113,6 +94,15 @@ const DynamicForm = ({
       questionInputComponent = (
         <BooleanInput
           value={value as boolean}
+          onChange={handleFormValueChange}
+        />
+      );
+      break;
+
+    case InputType.Map:
+      questionInputComponent = (
+        <MapPage
+          value={value as any} // TODO type this
           onChange={handleFormValueChange}
         />
       );

--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from "preact/hooks";
+import { ComponentChildren } from "preact";
+import { Boundary } from "src/components/maps/types";
 import { FormPageSchema, FormValue, QuestionType } from "../types";
 import MultiSelect from "./MultiSelect";
-import { JSXInternal } from "node_modules/preact/src/jsx";
 import Input from "./Input";
 import RadioButtons from "./RadioButtons";
 import BooleanInput from "./Checkbox";
@@ -40,7 +40,7 @@ const DynamicForm = ({
   value,
   onFormValueChange,
 }: DynamicFormProps) => {
-  let questionInputComponent: JSXInternal.Element | null = null;
+  let questionInputComponent: ComponentChildren | null = null;
 
   const handleFormValueChange = (newValue: FormValue) => {
     onFormValueChange(id, newValue);
@@ -101,10 +101,7 @@ const DynamicForm = ({
 
     case InputType.Map:
       questionInputComponent = (
-        <MapPage
-          value={value as any} // TODO type this
-          onChange={handleFormValueChange}
-        />
+        <MapPage value={value as Boundary} onChange={handleFormValueChange} />
       );
       break;
   }

--- a/dluhc-component-library/src/components/siteSelectionForm/components/FormPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/FormPage.tsx
@@ -21,7 +21,7 @@ const FormPage = ({
         <h1 className="my-2 text-4xl font-bold">{title}</h1>
         {subtitle && <p>{subtitle}</p>}
       </div>
-      <div className="form-page-body mb-4">{children}</div>
+      <div className="form-page-body my-4">{children}</div>
       <div className="form-page-footer mt-10 flex space-x-6">
         <button
           className="bg-gray-200 hover:bg-gray-300 text-black py-1 px-2"

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -1,0 +1,71 @@
+import AccordionDropdown from "src/components/accordianDropdown/AccordionDropdown";
+import MapComponent from "src/components/maps/MapComponent";
+
+interface MapPageProps {
+  value?: any;
+  onChange: (values: any) => void;
+}
+
+const MapPage = ({ onChange }: MapPageProps) => {
+  return (
+    <div className="flex flex-col mb-4">
+      <div className="my-4">
+        Draw the boundaries of your suggested site using the polygon icon on the
+        right of the map. You can edit the boundaries with the pencil icon.
+      </div>
+      <MapComponent
+        className="my-4"
+        style={{ height: "470px", width: "100%" }}
+        showDatasets={false}
+        onChange={onChange}
+      />
+      <AccordionDropdown text="Help drawing a site boundary">
+        <p className="mb-2">To draw the boundaries of your suggested site:</p>
+        <ul className="list-disc pl-8">
+          <li>
+            Type in a road name or postcode into the search bar at the top of
+            the map
+          </li>
+          <li>
+            Once you've found the area your site is in, use the polygon icon on
+            the right of the map to start drawing a boundary
+          </li>
+          <li>
+            Select the edges of the site until the whole site is within the blue
+            shape
+          </li>
+          <li>Double-click to finish the shape</li>
+        </ul>
+      </AccordionDropdown>
+      <AccordionDropdown text="Change or delete a site boundary">
+        <p className="mb-2">
+          If you want to make any changes to the site boundary once you've
+          finished, select the pencil icon on the right of the map to do so.
+        </p>
+        <p className="mb-2">
+          If you're not happy with the boundary you've drawn, select the delete
+          icon on the right of the map and start again.
+        </p>
+        <p className="mb-2">
+          If you want to change the map view - such as switching to aerial
+          pictures - select the gallary icon on the right of the map.
+        </p>
+      </AccordionDropdown>
+      <h2 className="my-4 text-3xl font-bold">
+        After you've drawn your boundary
+      </h2>
+      <p className="mt-4 mb-2">
+        It's helpful for us if you draw a boundary that's as accurate as
+        possible - but there's no need to do it over and over to get it exactly
+        right.
+      </p>
+      <p className="my-2">
+        We'll ask for your contact detaiuls later in the form, and we'll get in
+        touch if we have any questions about where the boundary line is intended
+        to be.
+      </p>
+    </div>
+  );
+};
+
+export default MapPage;

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -1,12 +1,13 @@
 import AccordionDropdown from "src/components/accordianDropdown/AccordionDropdown";
 import MapComponent from "src/components/maps/MapComponent";
+import { Boundary } from "src/components/maps/types";
 
 interface MapPageProps {
-  value?: any;
-  onChange: (values: any) => void;
+  value?: Boundary;
+  onChange: (values: Boundary) => void;
 }
 
-const MapPage = ({ onChange }: MapPageProps) => {
+const MapPage = ({ value, onChange }: MapPageProps) => {
   return (
     <div className="flex flex-col mb-4">
       <div className="my-4">
@@ -17,6 +18,7 @@ const MapPage = ({ onChange }: MapPageProps) => {
         className="my-4"
         style={{ height: "470px", width: "100%" }}
         showDatasets={false}
+        value={value}
         onChange={onChange}
       />
       <AccordionDropdown text="Help drawing a site boundary">

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -1,4 +1,5 @@
 import { StringSchema, NumberSchema, BooleanSchema } from "yup";
+import { Boundary } from "../maps/types";
 
 export type QuestionType =
   | "string"
@@ -22,7 +23,12 @@ export interface FormPageSchema {
   dependencies?: Record<string, FormPageSchema>;
 }
 
-export type FormValue = string | number | boolean | Record<string, boolean>;
+export type FormValue =
+  | string
+  | number
+  | boolean
+  | Record<string, boolean>
+  | Boundary;
 
 export type FormState = Record<string, FormValue>;
 

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -6,7 +6,8 @@ export type QuestionType =
   | "array"
   | "object"
   | "radio"
-  | "boolean";
+  | "boolean"
+  | "map";
 
 export interface FormPageSchema {
   type: QuestionType;

--- a/dluhc-component-library/src/components/timetablePage/Timetable.tsx
+++ b/dluhc-component-library/src/components/timetablePage/Timetable.tsx
@@ -3,11 +3,11 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import AccordionDropdown from "../accordianDropdown/AccordionDropdown";
 import { columnDefinitions } from "./columnDefinitions";
 import { TimetableStage } from "./types";
 
 import "./Timetable.css";
-import AccordionDropdown from "./AccordionDropdown";
 
 interface StagesProps {
   data?: TimetableStage[];
@@ -48,7 +48,7 @@ const Timetable = ({ data }: StagesProps) => {
               </tr>
               <tr className="border-b">
                 <td colSpan={4}>
-                  <AccordionDropdown>
+                  <AccordionDropdown text="More information">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
                     do eiusmod tempor incididunt ut labore et dolore magna
                     aliqua. Ut enim ad minim veniam, quis nostrud exercitation

--- a/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
+++ b/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
@@ -3,7 +3,7 @@ import csvToJson from "csvtojson";
 import { loadCSV, loadJson } from "../../utils";
 import Timetable from "./Timetable";
 import { TimetableHeader, TimetableStage } from "./types";
-import AccordionDropdown from "./AccordionDropdown";
+import AccordionDropdown from "../accordianDropdown/AccordionDropdown";
 
 interface TimetablePageProps {
   stagesFilepath: string;
@@ -77,7 +77,7 @@ const TimetablePage = ({
             <p>Status: {timetableHeaderData?.status}</p>
             <p>Period: {timetableHeaderData?.periodStartToEnd}</p>
             <p>Coverage: {timetableHeaderData?.coverage}</p>
-            <AccordionDropdown></AccordionDropdown>
+            <AccordionDropdown text="More information"></AccordionDropdown>
           </div>
         </div>
         <div>

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -120,3 +120,29 @@ export const ConditionalPage = {
     },
   },
 };
+
+export const MapPage = {
+  args: {
+    data: {
+      required: [],
+      type: "object",
+      properties: {
+        groupedExample: {
+          type: "object",
+          properties: {
+            boundaryDataMap: {
+              type: "map", // This isnt a real type, we should define a real data schema for geo data and have this in a ui schema
+              title: "Where are the boundaries of this site?",
+            },
+            unrelatedQuestion: {
+              type: "string",
+              title: "Unrelated question",
+              subtitle:
+                "This question should come after the Parent and Additional questions",
+            },
+          },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
This PR adds a basic map page to the dynamic form.

Currently its using a schema type of "map" which is not valid. This is just temporary until the form supports a uiSchema alongside the jsonSchema.

![image](https://github.com/digital-land/plan-making/assets/97245023/25de8a2b-365d-4b8f-adda-213f7275f3c2)
