### PR TITLE
DLUHC-176 Site selection UI schema

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -12,13 +12,20 @@ import {
 import { loadJson } from "src/utils";
 import DynamicForm from "./components/DynamicForm";
 import FormPage from "./components/FormPage";
-import { FormState, FormValue, FormPageSchema, ValidationShape } from "./types";
+import {
+  FormState,
+  FormValue,
+  FormPageSchema,
+  ValidationShape,
+  UiSchema,
+} from "./types";
 
 import "./SiteSelectionForm.css";
 
 interface SiteSelectionForm {
   filepath?: string;
   data?: FormPageSchema;
+  uiSchema?: UiSchema;
 }
 
 const createValidationSchema = (key: string, formSchema: FormPageSchema) => {
@@ -129,7 +136,7 @@ const createFlatFormSchema = (
 
 const queryClient = new QueryClient();
 
-const SiteSelectionForm = ({ filepath, data }: SiteSelectionForm) => {
+const SiteSelectionForm = ({ filepath, data, uiSchema }: SiteSelectionForm) => {
   const [baseSchema, setBaseSchema] = useState<FormPageSchema | null>(null);
 
   const [formData, setFormData] = useState<FormState>({});
@@ -224,6 +231,7 @@ const SiteSelectionForm = ({ filepath, data }: SiteSelectionForm) => {
             <DynamicForm
               id={currentPageId}
               formPageSchema={formSchema.properties[currentPageId]}
+              uiSchema={uiSchema?.[currentPageId]}
               value={formData[currentPageId]}
               onFormValueChange={handleFormValueChange}
             />

--- a/dluhc-component-library/src/components/siteSelectionForm/components/RadioButtons.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/RadioButtons.tsx
@@ -1,31 +1,26 @@
-interface RadioButtonsProps {
-  name: string;
-  options: ReadonlyArray<string>;
-  value: String;
-  onChange: (values: string) => void;
+import { RadioOption } from "../types";
+
+interface RadioButtonsProps<T extends string | boolean> {
+  options: ReadonlyArray<RadioOption>;
+  value: T;
+  onChange: (values: T) => void;
 }
 
-const RadioButtons = ({
-  name,
+const RadioButtons = <T extends string | boolean>({
   options,
   value,
   onChange,
-}: RadioButtonsProps) => {
-  if (!options.length) {
-    return null;
-  }
-
-  const optionComponents = options.map((key) => (
-    <div key={key} className="flex items-center mb-4">
+}: RadioButtonsProps<T>) => {
+  const optionComponents = options.map((option) => (
+    <div key={option.value} className="flex items-center mb-4">
       <label className="font-semibold flex">
         <input
           type="radio"
           class="radio mr-2"
-          name={name}
-          checked={value === key}
-          onClick={() => onChange(key)}
+          checked={value === option.value}
+          onClick={() => onChange(option.value)}
         />
-        <span>{key}</span>
+        <span>{option.label}</span>
       </label>
     </div>
   ));

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -1,14 +1,7 @@
 import { StringSchema, NumberSchema, BooleanSchema } from "yup";
 import { Boundary } from "../maps/types";
 
-export type QuestionType =
-  | "string"
-  | "number"
-  | "array"
-  | "object"
-  | "radio"
-  | "boolean"
-  | "map";
+export type QuestionType = "string" | "number" | "array" | "object" | "boolean";
 
 export interface FormPageSchema {
   type: QuestionType;
@@ -33,3 +26,14 @@ export type FormValue =
 export type FormState = Record<string, FormValue>;
 
 export type ValidationShape = StringSchema | NumberSchema | BooleanSchema;
+
+export type Widget = "map" | "radio";
+
+export type UiPropertySchema = { "ui:widget"?: Widget };
+
+export type UiSchema = Record<string, UiPropertySchema>;
+
+export type RadioOption = {
+  label: string;
+  value: string | boolean;
+};

--- a/dluhc-component-library/src/components/siteSelectionForm/utils.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/utils.ts
@@ -1,0 +1,18 @@
+import { FormPageSchema, RadioOption } from "./types";
+
+export const convertPropertyToOptions: (
+  property: FormPageSchema,
+) => ReadonlyArray<RadioOption> = (property) => {
+  if (property.type === "boolean") {
+    return [
+      { label: "Yes", value: true },
+      { label: "No", value: false },
+    ];
+  }
+
+  if (property.type === "string" && property?.enum?.length) {
+    return property.enum.map((value) => ({ label: value, value }));
+  }
+
+  return [];
+};

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -53,17 +53,16 @@ export const Default = {
           type: "string",
           title: "Your relationship to the site",
           enum: [
-            "landowner",
-            "developer",
-            "local-authority",
-            "planning-agent",
-            "none",
+            "Landowner",
+            "Developer",
+            "Local Authority",
+            "Planning Agent",
+            "None",
           ],
         },
         isBrownfieldSite: {
-          type: "radio",
+          type: "boolean",
           title: "Is this a Brownfield Site? ",
-          enum: ["Yes", "No"],
         },
         age: {
           type: "number",
@@ -76,6 +75,14 @@ export const Default = {
           type: "string",
           title: "Please provide the fullest postal address you can",
         },
+      },
+    },
+    uiSchema: {
+      relationshipTo: {
+        "ui:widget": "radio",
+      },
+      isBrownfieldSite: {
+        "ui:widget": "radio",
       },
     },
   },
@@ -131,7 +138,7 @@ export const MapPage = {
           type: "object",
           properties: {
             boundaryDataMap: {
-              type: "map", // This isnt a real type, we should define a real data schema for geo data and have this in a ui schema
+              type: "map", // This isnt a real type should be number[][][], this can be changed when the array PR is merged
               title: "Where are the boundaries of this site?",
             },
             unrelatedQuestion: {
@@ -142,6 +149,11 @@ export const MapPage = {
             },
           },
         },
+      },
+    },
+    uiSchema: {
+      boundaryDataMap: {
+        "ui:widget": "map",
       },
     },
   },


### PR DESCRIPTION
Adds a basic uiSchema so that we handle maps and radio options more inline with jsonSchema + uiSchema.

The Radio component now handles both strings and booleans but still allows the validation system to check its the correct value.

![image](https://github.com/digital-land/plan-making/assets/97245023/77f653bf-3e56-4f3a-8e36-675c3ad8c152)
![image](https://github.com/digital-land/plan-making/assets/97245023/841e4157-968b-412c-92c2-390a22428216)

The map page hasnt really been changed, ideally i was hoping to be able to change the the jsonSchema type to be the correct type but this requires the array PR to me merged.

![image](https://github.com/digital-land/plan-making/assets/97245023/bb722294-0e0b-4582-9d9e-56ca6f74df11)
