### PR TITLE
Fix radio option value type

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/components/RadioButtons.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/RadioButtons.tsx
@@ -1,7 +1,7 @@
 import { RadioOption } from "../types";
 
 interface RadioButtonsProps<T extends string | boolean> {
-  options: ReadonlyArray<RadioOption>;
+  options: ReadonlyArray<RadioOption<T>>;
   value: T;
   onChange: (values: T) => void;
 }

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -33,7 +33,7 @@ export type UiPropertySchema = { "ui:widget"?: Widget };
 
 export type UiSchema = Record<string, UiPropertySchema>;
 
-export type RadioOption = {
+export type RadioOption<T extends string | boolean> = {
   label: string;
-  value: string | boolean;
+  value: T;
 };


### PR DESCRIPTION
The type of the radio button option value was `string | boolean` however this wasnt being aligned with the type that was being given to the radio button component. This type is now dynamic and driven by the type of the radio button component