### PR TITLE
DLUHC-264 editable map boundary

### DIFF
--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -30,16 +30,16 @@ interface DrawingMapProps {
   strokeColor?: string;
   fillColor?: string;
   strokeWidth?: number;
-  circleRadius?: number;
-  circleFillColor?: string;
+  vertexPoints?: number;
+  vertexRadius?: number;
 }
 
 const DrawingMapProperties = {
   strokeColor: "#ffcc33",
   fillColor: "rgba(255, 255, 255, 0.2)",
   strokeWidth: 2,
-  circleRadius: 7,
-  circleFillColor: "#ffcc33",
+  vertexPoints: 4,
+  vertexRadius: 5,
 };
 
 const BaseMapProperties = {
@@ -101,8 +101,8 @@ const MapComponent = ({
           strokeColor={customDrawingProperties.strokeColor}
           fillcolor={customDrawingProperties.fillColor}
           strokeWidth={customDrawingProperties.strokeWidth}
-          circleRadius={customDrawingProperties.circleRadius}
-          circleFillColor={customDrawingProperties.circleFillColor}
+          vertexPoints={customDrawingProperties.vertexPoints}
+          vertexRadius={customDrawingProperties.vertexRadius}
           value={value}
           onChange={onChange}
         />

--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -32,6 +32,9 @@ interface DrawingMapProps {
   strokeWidth?: number;
   vertexPoints?: number;
   vertexRadius?: number;
+  pointerStrokeColor?: string;
+  pointerFillColor?: string;
+  pointerRadius?: number;
 }
 
 const DrawingMapProperties = {
@@ -40,6 +43,9 @@ const DrawingMapProperties = {
   strokeWidth: 2,
   vertexPoints: 4,
   vertexRadius: 5,
+  pointerStrokeColor: "white",
+  pointerFillColor: "#DD6970",
+  pointerRadius: 5,
 };
 
 const BaseMapProperties = {
@@ -98,11 +104,7 @@ const MapComponent = ({
       </div>
       {customBaseMapProperties.isDrawingMode && (
         <DrawingLayer
-          strokeColor={customDrawingProperties.strokeColor}
-          fillColor={customDrawingProperties.fillColor}
-          strokeWidth={customDrawingProperties.strokeWidth}
-          vertexPoints={customDrawingProperties.vertexPoints}
-          vertexRadius={customDrawingProperties.vertexRadius}
+          {...customDrawingProperties}
           value={value}
           onChange={onChange}
         />

--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -35,8 +35,8 @@ interface DrawingMapProps {
 }
 
 const DrawingMapProperties = {
-  strokeColor: "#ffcc33",
-  fillColor: "rgba(255, 255, 255, 0.2)",
+  strokeColor: "#DD6970",
+  fillColor: "rgba(221, 105, 112, 0.1)",
   strokeWidth: 2,
   vertexPoints: 4,
   vertexRadius: 5,
@@ -99,7 +99,7 @@ const MapComponent = ({
       {customBaseMapProperties.isDrawingMode && (
         <DrawingLayer
           strokeColor={customDrawingProperties.strokeColor}
-          fillcolor={customDrawingProperties.fillColor}
+          fillColor={customDrawingProperties.fillColor}
           strokeWidth={customDrawingProperties.strokeWidth}
           vertexPoints={customDrawingProperties.vertexPoints}
           vertexRadius={customDrawingProperties.vertexRadius}

--- a/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
+++ b/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
@@ -63,7 +63,7 @@ const DrawingLayer = ({
 
   const outlineStyle = useMemo(
     () => new Style({ fill, stroke }),
-    [fillColor, strokeColor, strokeWidth],
+    [fill, stroke],
   );
 
   const vertexStyle = useMemo(() => {

--- a/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
+++ b/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
@@ -122,6 +122,7 @@ const DrawingLayer = ({
 
     return () => {
       map?.removeInteraction(draw);
+      map?.removeInteraction(modify);
     };
   }, [map, source]);
 

--- a/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
+++ b/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
@@ -11,6 +11,7 @@ import CircleStyle from "ol/style/Circle";
 import { useEffect, useMemo, useRef } from "preact/compat";
 import { useMap } from "src/contexts/mapContext";
 import { Boundary } from "../types";
+import { isPolygon } from "../utils";
 
 interface DrawingLayerProps {
   zIndex?: number;
@@ -77,11 +78,9 @@ const DrawingLayer = ({
       }),
       geometry: (feature: FeatureLike) => {
         const polygon = feature.getGeometry();
-        if (polygon) {
-          const coordinates: number[][] = (
-            polygon as Polygon
-          ).getCoordinates()[0];
-          return new MultiPoint(coordinates);
+
+        if (isPolygon(polygon)) {
+          return new MultiPoint(polygon.getCoordinates()[0]);
         }
       },
     });

--- a/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
+++ b/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
@@ -14,7 +14,7 @@ import { Boundary } from "../types";
 interface DrawingLayerProps {
   zIndex?: number;
   strokeColor?: string;
-  fillcolor?: string;
+  fillColor?: string;
   strokeWidth?: number;
   vertexPoints?: number;
   vertexRadius?: number;
@@ -24,8 +24,8 @@ interface DrawingLayerProps {
 
 const DrawingLayer = ({
   zIndex = 2,
-  strokeColor = "#ffcc33",
-  fillcolor = "rgba(255, 255, 255, 0.2)",
+  strokeColor = "#DD6970",
+  fillColor = "rgba(221, 105, 112, 0.1)",
   strokeWidth = 2,
   vertexPoints = 4,
   vertexRadius = 5,
@@ -38,14 +38,14 @@ const DrawingLayer = ({
 
   useEffect(() => {
     const outlineStyle = new Style({
-      fill: new Fill({ color: fillcolor }),
+      fill: new Fill({ color: fillColor }),
       stroke: new Stroke({ color: strokeColor, width: strokeWidth }),
     });
 
     const vertexStyle = new Style({
       image: new RegularShape({
         fill: new Fill({
-          color: fillcolor,
+          color: fillColor,
         }),
         stroke: new Stroke({
           color: strokeColor,
@@ -76,7 +76,7 @@ const DrawingLayer = ({
   }, [
     map,
     source,
-    fillcolor,
+    fillColor,
     strokeColor,
     strokeWidth,
     vertexPoints,

--- a/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
+++ b/dluhc-component-library/src/components/maps/components/DrawingLayer.tsx
@@ -7,7 +7,7 @@ import { ModifyEvent } from "ol/interaction/Modify";
 import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import { Fill, RegularShape, Stroke, Style } from "ol/style";
-import { useEffect, useRef } from "preact/compat";
+import { useEffect, useMemo, useRef } from "preact/compat";
 import { useMap } from "src/contexts/mapContext";
 import { Boundary } from "../types";
 
@@ -36,13 +36,15 @@ const DrawingLayer = ({
 
   const source = useRef(new VectorSource());
 
-  useEffect(() => {
-    const outlineStyle = new Style({
+  const outlineStyle = useMemo(() => {
+    return new Style({
       fill: new Fill({ color: fillColor }),
       stroke: new Stroke({ color: strokeColor, width: strokeWidth }),
     });
+  }, [fillColor, strokeColor, strokeWidth]);
 
-    const vertexStyle = new Style({
+  const vertexStyle = useMemo(() => {
+    return new Style({
       image: new RegularShape({
         fill: new Fill({
           color: fillColor,
@@ -65,7 +67,9 @@ const DrawingLayer = ({
         }
       },
     });
+  }, [fillColor, strokeColor, strokeWidth, vertexPoints, vertexRadius]);
 
+  useEffect(() => {
     const layer = new VectorLayer({
       source: source.current,
       style: [outlineStyle, vertexStyle],
@@ -73,16 +77,7 @@ const DrawingLayer = ({
     });
     map.addLayer(layer);
     return () => map?.removeLayer(layer);
-  }, [
-    map,
-    source,
-    fillColor,
-    strokeColor,
-    strokeWidth,
-    vertexPoints,
-    vertexRadius,
-    zIndex,
-  ]);
+  }, [map, source, outlineStyle, vertexStyle, zIndex]);
 
   useEffect(() => {
     source.current.clear(); // for now, only allow 1 boundary to be drawn

--- a/dluhc-component-library/src/components/maps/utils.ts
+++ b/dluhc-component-library/src/components/maps/utils.ts
@@ -1,0 +1,6 @@
+import { Geometry, Polygon } from "ol/geom";
+import RenderFeature from "ol/render/Feature";
+
+export const isPolygon = (
+  polygon: Geometry | RenderFeature | undefined,
+): polygon is Polygon => polygon?.getType() === "Polygon";

--- a/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
+++ b/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
@@ -22,6 +22,9 @@ interface DrawingMapProps {
   strokeWidth: number;
   circleRadius: number;
   circleFillColor: string;
+  pointerStrokeColor: string;
+  pointerFillColor: string;
+  pointerRadius: number;
 }
 
 const queryClient = new QueryClient();
@@ -68,6 +71,9 @@ export const Default = {
       strokeWidth: 2,
       vertexPoints: 4,
       vertexRadius: 5,
+      pointerStrokeColor: "white",
+      pointerFillColor: "#DD6970",
+      pointerRadius: 5,
     },
   },
 };

--- a/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
+++ b/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
@@ -63,8 +63,8 @@ export const Default = {
       style: { height: "500px", width: "500px" },
     },
     drawingMapProps: {
-      strokeColor: "#ffcc33",
-      fillColor: "rgba(255, 255, 255, 0.2)",
+      strokeColor: "#DD6970",
+      fillColor: "rgba(221, 105, 112, 0.1)",
       strokeWidth: 2,
       vertexPoints: 4,
       vertexRadius: 5,

--- a/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
+++ b/dluhc-component-library/src/stories/DrawingLayer.stories.tsx
@@ -66,8 +66,8 @@ export const Default = {
       strokeColor: "#ffcc33",
       fillColor: "rgba(255, 255, 255, 0.2)",
       strokeWidth: 2,
-      circleRadius: 7,
-      circleFillColor: "#ffcc33",
+      vertexPoints: 4,
+      vertexRadius: 5,
     },
   },
 };


### PR DESCRIPTION
This add a new interaction to the drawing layer which allows a drawn boundary to be edited. These edits are: moving the vertices (corners) of the polygon or adding more vertices. Every time an edit finishes, the updated coordinates are emitted as an output of the `DrawingLayer` and `MapComponent`, in the same way the initial boundary is emitted with the `onChange` callback.

- Added interaction to drawing layer for modifying drawn boundary.
- Updated props to allow vertex shape, size and radius to be configurable.
- Updated drawing default props to use red colours to make it easier to see on the map.
- Also added props to configure drawing pointer style.

![image](https://github.com/digital-land/plan-making/assets/47323438/d79539ed-05a8-41ae-80fa-b8ea256916d7)
