### PR TITLE
Fix required being deleted from top level form

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/SiteSelectionForm.tsx
@@ -81,13 +81,10 @@ const addChildProperties = (
     ...childSchema.properties,
   };
 
-  let newRequired: ReadonlyArray<string> = [];
+  let newRequired: ReadonlyArray<string> = [...(baseFormSchema.required ?? [])];
 
   if (childSchema.required?.length) {
-    newRequired = [
-      ...(baseFormSchema.required as string[]),
-      ...childSchema.required,
-    ];
+    newRequired = [...newRequired, ...childSchema.required];
   }
 
   const updatedFormSchema: FormPageSchema = {
@@ -108,12 +105,8 @@ const createFlatFormSchema = (
     title: formSchema.title,
     dependencies: {},
     properties: {},
-    required: [],
+    required: formSchema.required ?? [],
   };
-
-  if (formSchema.required?.length) {
-    newSchema.required = formSchema.required;
-  }
 
   const propertyKeys = Object.keys(formSchema?.properties || {});
 

--- a/dluhc-component-library/src/stories/SiteSelection.stories.tsx
+++ b/dluhc-component-library/src/stories/SiteSelection.stories.tsx
@@ -134,19 +134,24 @@ export const MapPage = {
       required: ["boundaryDataMap"],
       type: "object",
       properties: {
-        boundaryDataMap: {
-          type: "array",
-          title: "Where are the boundaries of this site?",
-          items: {
-            type: "array",
-            items: { type: "array", items: { type: "number" } },
+        groupedExample: {
+          type: "object",
+          properties: {
+            boundaryDataMap: {
+              type: "array",
+              title: "Where are the boundaries of this site?",
+              items: {
+                type: "array",
+                items: { type: "array", items: { type: "number" } },
+              },
+            },
+            unrelatedQuestion: {
+              type: "string",
+              title: "Unrelated question",
+              subtitle:
+                "This question should come after the Parent and Additional questions",
+            },
           },
-        },
-        unrelatedQuestion: {
-          type: "string",
-          title: "Unrelated question",
-          subtitle:
-            "This question should come after the Parent and Additional questions",
         },
       },
     },


### PR DESCRIPTION
There was a bug that was deleting the `required` field from a property if it had a child that didnt have any required values. 

The code now always adds the parent required values. 