### PR TITLE
DLUHC-201 add timetable form skeleton

### DIFF
--- a/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
+++ b/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
@@ -1,0 +1,42 @@
+import { useMemo, useState } from "preact/hooks";
+import DescriptionPage from "./components/DescriptionPage";
+import PageFooter from "./components/PageFooter";
+import StagesPage from "./components/StagesPage";
+import TitlePage from "./components/TitlePage";
+
+const TIMETABLE_FORM_PAGES = new Map([
+  ["title", TitlePage],
+  ["description", DescriptionPage],
+  ["stages", StagesPage],
+]);
+
+const TIMETABLE_PAGE_IDS = ["title", "description", "stages"];
+
+const TimetableForm = () => {
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const currentPageId = useMemo(
+    () => TIMETABLE_PAGE_IDS[currentPage],
+    [currentPage],
+  );
+
+  const PageComponent = useMemo(
+    () => TIMETABLE_FORM_PAGES.get(currentPageId),
+    [currentPage],
+  );
+
+  return (
+    <div>
+      <div>{PageComponent && <PageComponent />}</div>
+      <PageFooter
+        currentPage={currentPage}
+        totalPages={TIMETABLE_PAGE_IDS.length}
+        onBackClick={() => setCurrentPage(currentPage - 1)}
+        onNextClick={() => setCurrentPage(currentPage + 1)}
+        onSaveClick={() => {}}
+      />
+    </div>
+  );
+};
+
+export default TimetableForm;

--- a/dluhc-component-library/src/components/timetableForm/components/DescriptionPage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/DescriptionPage.tsx
@@ -1,0 +1,12 @@
+const DescriptionPage = () => {
+  return (
+    <div className="flex items-center my-8">
+      <label className="font-semibold flex flex-col">
+        <h1 className="my-2 text-4xl font-bold">Description</h1>
+        <textarea class="text mr-2 border-2 border-black py-1 px-2" />
+      </label>
+    </div>
+  );
+};
+
+export default DescriptionPage;

--- a/dluhc-component-library/src/components/timetableForm/components/PageFooter.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/PageFooter.tsx
@@ -1,0 +1,46 @@
+interface PageFooterProps {
+  currentPage: number;
+  totalPages: number;
+  onBackClick: () => void;
+  onNextClick: () => void;
+  onSaveClick: () => void;
+}
+
+const PageFooter = ({
+  currentPage,
+  totalPages,
+  onBackClick,
+  onNextClick,
+  onSaveClick,
+}: PageFooterProps) => {
+  return (
+    <div>
+      {currentPage !== 0 && (
+        <button
+          className="bg-gray-200 hover:bg-gray-300 text-black py-1 px-2 mr-5"
+          onClick={onBackClick}
+        >
+          Back
+        </button>
+      )}
+      {currentPage < totalPages - 1 && (
+        <button
+          className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+          onClick={onNextClick}
+        >
+          Save and continue
+        </button>
+      )}
+      {currentPage === totalPages - 1 && (
+        <button
+          className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+          onClick={onSaveClick}
+        >
+          Save and complete
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default PageFooter;

--- a/dluhc-component-library/src/components/timetableForm/components/StagesPage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/StagesPage.tsx
@@ -1,0 +1,51 @@
+const PROGRESS_OPTIONS = [
+  { id: "notStarted", name: "Not Started" },
+  { id: "delayed", name: "Delayed" },
+  { id: "inProgress", name: "In Progress" },
+  { id: "finished", name: "Finished" },
+];
+
+const StagesPage = () => {
+  return (
+    <div className="flex items-center my-8">
+      <label className="font-semibold flex flex-col">
+        <h1 className="my-2 text-4xl font-bold">Stages</h1>
+
+        <label className="font-semibold flex flex-col">
+          Event
+          <input
+            class="text mr-2 border-2 border-black py-1 px-2"
+            type="text"
+          />
+        </label>
+
+        <label className="font-semibold flex flex-col">
+          Start Date
+          <input
+            class="text mr-2 border-2 border-black py-1 px-2"
+            type="month"
+          />
+        </label>
+
+        <label className="font-semibold flex flex-col">
+          End Date
+          <input
+            class="text mr-2 border-2 border-black py-1 px-2"
+            type="month"
+          />
+        </label>
+
+        <label className="font-semibold flex flex-col">
+          Progress
+          <select class="text mr-2 border-2 border-black py-1 px-2" type="text">
+            {PROGRESS_OPTIONS.map((value) => (
+              <option key={value.id}>{value.name}</option>
+            ))}
+          </select>
+        </label>
+      </label>
+    </div>
+  );
+};
+
+export default StagesPage;

--- a/dluhc-component-library/src/components/timetableForm/components/TitlePage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/TitlePage.tsx
@@ -1,0 +1,12 @@
+const TitlePage = () => {
+  return (
+    <div className="flex items-center my-8">
+      <label className="font-semibold flex flex-col">
+        <h1 className="my-2 text-4xl font-bold">Title</h1>
+        <input class="text mr-2 border-2 border-black py-1 px-2" type="text" />
+      </label>
+    </div>
+  );
+};
+
+export default TitlePage;

--- a/dluhc-component-library/src/stories/TimetableForm.stories.tsx
+++ b/dluhc-component-library/src/stories/TimetableForm.stories.tsx
@@ -1,0 +1,11 @@
+import TimetableForm from "src/components/timetableForm/TimetableForm";
+
+export default {
+  component: TimetableForm,
+  title: "SOW14/Timetable Form",
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {},
+};


### PR DESCRIPTION
Added skeleton timetable form, connecting the inputs to state will be added in the next PR.
- Added `TimetableForm` component
- Added `Title`, `Description` and `Stages` pages for the form, plus a common `Footer` component.

![image](https://github.com/digital-land/plan-making/assets/47323438/5f86a6a4-f722-4570-acc1-d3bfc84797a3)
![image](https://github.com/digital-land/plan-making/assets/47323438/ea60bbc7-9e61-49ea-aa95-211a6e6bb33c)
![image](https://github.com/digital-land/plan-making/assets/47323438/cbdb5384-a98b-42d4-a9c1-817dcb2be005)
