### PR TITLE
Misc Prepare site selection map for User Research

### DIFF
--- a/dluhc-component-library/src/components/accordianDropdown/AccordionDropdown.tsx
+++ b/dluhc-component-library/src/components/accordianDropdown/AccordionDropdown.tsx
@@ -5,9 +5,14 @@ import { IndicationArrow } from "../inlinesvgs/IndicationArrow";
 interface AccordionDropdownProps {
   text: string;
   children?: ComponentChildren;
+  className?: string;
 }
 
-const AccordionDropdown = ({ text, children }: AccordionDropdownProps) => {
+const AccordionDropdown = ({
+  text,
+  children,
+  className,
+}: AccordionDropdownProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleDropdownClicked = () => {
@@ -16,11 +21,10 @@ const AccordionDropdown = ({ text, children }: AccordionDropdownProps) => {
 
   const rotationClass = isExpanded ? "rotate-90" : "";
 
+  const containerClass = `pt-1 pb-3 cursor-pointer w-fit ${className}`;
+
   return (
-    <div
-      className="pt-1 pb-3 cursor-pointer w-fit"
-      onClick={handleDropdownClicked}
-    >
+    <div className={containerClass} onClick={handleDropdownClicked}>
       <IndicationArrow
         className={`h-3 w-3 transition-all inline-block ${rotationClass}`}
       />

--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -57,7 +57,7 @@ const BaseMapProperties = {
 
 const MapComponent = ({
   id,
-  className = "map-container",
+  className,
   style = { height: "700px", width: "100%" },
   showDatasets = true,
   value,
@@ -86,8 +86,10 @@ const MapComponent = ({
     }
   };
 
+  const containerClassName = `map-container ${className}`;
+
   return (
-    <MapContainer id={id} className={className} style={style}>
+    <MapContainer id={id} className={containerClassName} style={style}>
       <BaseMap
         lat={customBaseMapProperties.lat}
         lng={customBaseMapProperties.lng}

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -17,7 +17,6 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
       <MapComponent
         className="my-4"
         style={{ height: "470px", width: "100%" }}
-        showDatasets={false}
         value={value}
         onChange={onChange}
       />

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -62,7 +62,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
         right.
       </p>
       <p className="my-2">
-        We'll ask for your contact detaiuls later in the form, and we'll get in
+        We'll ask for your contact details later in the form, and we'll get in
         touch if we have any questions about where the boundary line is intended
         to be.
       </p>


### PR DESCRIPTION
We are likely going to be showing the boundary selection page from the site identification form during our User Research sessions. 

This PR is just tiding up some typos and styling so that its more presentable during those meetings.

![image](https://github.com/digital-land/plan-making/assets/97245023/6ac69ef5-aead-4f55-bd20-f12dae838279)
