### PR TITLE
DLUHC-176 Add risk request and display to boundary selection page

### DIFF
--- a/dluhc-component-library/src/components/maps/components/DatasetLayer.tsx
+++ b/dluhc-component-library/src/components/maps/components/DatasetLayer.tsx
@@ -13,7 +13,7 @@ interface DatasetlayerProps {
 }
 
 const DatasetLayer = ({ area, dataset, zIndex = 1 }: DatasetlayerProps) => {
-  const { data, isLoading, isError } = useFetchEntities(dataset.dataset, area);
+  const { data, isLoading, isError } = useFetchEntities(area, dataset.dataset);
 
   if (isLoading || isError) {
     return null;

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -10,11 +10,13 @@ interface MapPageProps {
   onChange: (values: Boundary) => void;
 }
 
+// TODO we probably should move these to an API constants file or a PDP model file
 const GREEN_BELT = "green-belt";
 const ANCIENT_WOODLAND = "ancient-woodland";
 
 const RISKS = [GREEN_BELT, ANCIENT_WOODLAND];
 
+// TODO these should probably come from a network request to PDP like the datalist does
 const RISK_LABELS: Record<string, string> = {
   [GREEN_BELT]: "Green belt",
   [ANCIENT_WOODLAND]: "Ancient woodland",
@@ -32,24 +34,19 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
 
   const { data: riskData, isFetching } = useFetchEntities(polygon);
 
-  const activeRisks = useMemo(() => {
-    const allRisks = riskData?.features.reduce<ReadonlyArray<string>>(
-      (riskList, feature) => {
+  const activeRisks = useMemo(
+    () =>
+      riskData?.features.reduce<ReadonlyArray<string>>((riskList, feature) => {
         const dataset = feature.properties?.dataset;
-
-        console.log(dataset);
 
         if (!riskList.includes(dataset) && RISKS.includes(dataset)) {
           return [...riskList, dataset];
         }
 
         return riskList;
-      },
-      [],
-    );
-
-    return allRisks;
-  }, [riskData]);
+      }, []),
+    [riskData],
+  );
 
   const hasRisks = value && !isFetching && !!activeRisks?.length;
 

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -10,7 +10,19 @@ interface MapPageProps {
   onChange: (values: Boundary) => void;
 }
 
-const RISKS = ["green-belt"];
+const GREEN_BELT = "green-belt";
+const ANCIENT_WOODLAND = "ancient-woodland";
+
+const RISKS = [GREEN_BELT, ANCIENT_WOODLAND];
+
+const RISK_LABELS: Record<string, string> = {
+  [GREEN_BELT]: "Green belt",
+  [ANCIENT_WOODLAND]: "Ancient woodland",
+};
+
+const renderRisks = (activeRisks: ReadonlyArray<string>) => {
+  return activeRisks.map((risk) => <li>{RISK_LABELS[risk]}</li>);
+};
 
 const MapPage = ({ value, onChange }: MapPageProps) => {
   const polygon = useMemo(
@@ -18,12 +30,14 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
     [value],
   );
 
-  const { data: riskData, isFetching, isError } = useFetchEntities(polygon);
+  const { data: riskData, isFetching } = useFetchEntities(polygon);
 
   const activeRisks = useMemo(() => {
     const allRisks = riskData?.features.reduce<ReadonlyArray<string>>(
       (riskList, feature) => {
         const dataset = feature.properties?.dataset;
+
+        console.log(dataset);
 
         if (!riskList.includes(dataset) && RISKS.includes(dataset)) {
           return [...riskList, dataset];
@@ -37,12 +51,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
     return allRisks;
   }, [riskData]);
 
-  const riskSection =
-    isFetching || !activeRisks ? (
-      <p>Loading...</p>
-    ) : (
-      activeRisks.map((risk) => <p className="my-2">{risk}</p>)
-    );
+  const hasRisks = value && !isFetching && !!activeRisks?.length;
 
   return (
     <div className="flex flex-col mb-4">
@@ -91,7 +100,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
       <h2 className="my-4 text-3xl font-bold">
         After you've drawn your boundary
       </h2>
-      <p className="mt-4 mb-2">
+      <p className="my-2">
         It's helpful for us if you draw a boundary that's as accurate as
         possible - but there's no need to do it over and over to get it exactly
         right.
@@ -101,8 +110,25 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
         touch if we have any questions about where the boundary line is intended
         to be.
       </p>
-      <h2 className="my-4 text-3xl font-bold">Risks</h2>
-      {riskSection}
+      {isFetching && <p className="my-8">Loading...</p>}
+      {hasRisks && (
+        <>
+          <h2 className="my-4 text-3xl font-bold">
+            Your site has flagged some risks
+          </h2>
+          <p className="my-2">
+            Planning data shows that some or all of your site is located in a
+            restricted area.
+          </p>
+          <p className="my-2">You can:</p>
+          <ul className="list-disc pl-8">
+            <li>Tell us how to mitigate the risks on the next screens</li>
+            <li>Change the site boundary on the map</li>
+          </ul>
+          <p className="my-2">Identified risks:</p>
+          <ul className="list-disc pl-8">{renderRisks(activeRisks)}</ul>
+        </>
+      )}
     </div>
   );
 };

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -1,5 +1,5 @@
 import { Polygon } from "ol/geom";
-import { useMemo } from "react";
+import { useMemo } from "preact/hooks";
 import { useFetchEntities } from "src/api/planningData/api";
 import AccordionDropdown from "src/components/accordianDropdown/AccordionDropdown";
 import MapComponent from "src/components/maps/MapComponent";


### PR DESCRIPTION
Adds the base risk functionality to the boundary selection page.

Whenever a new boundary is drawn, it sends a requests to PDP to see what areas it overlaps with. It then compares that to a list of datasets we actually care about and flags any that match.

In the future we would hopefully be able ask PDP to only check datasets we care about rather than checking them all and filtering down after which is much slower.

I need to have a think about how we want to store the constants used in this as some of them will come from the jsonSchema / uiSchema but they need to match with PDP.

**Loading**

![image](https://github.com/digital-land/plan-making/assets/97245023/4fd3ab17-7444-4a94-ace6-2faa7fb6ab02)

**Risks**
![image](https://github.com/digital-land/plan-making/assets/97245023/9ab2cecc-2347-496e-87ec-7e0d2b3b6b43)


**Notes**
This PR is pointed towards the `dluhc-176-boundary-risks` branch instead of main since the map component is being used in user research sessions so we dont want half finished functionality being added there during interviews.