### PR TITLE
Add filter for dataset list

### DIFF
--- a/dluhc-component-library/src/components/maps/MapComponent.tsx
+++ b/dluhc-component-library/src/components/maps/MapComponent.tsx
@@ -12,6 +12,7 @@ interface MapComponentProps {
   baseMapProps?: BaseMapProps;
   drawingMapProps?: DrawingMapProps;
   showDatasets?: boolean;
+  datasetFilterList?: ReadonlyArray<string>;
   id?: string;
   className?: string;
   style?: CSSProperties;
@@ -60,6 +61,7 @@ const MapComponent = ({
   className,
   style = { height: "700px", width: "100%" },
   showDatasets = true,
+  datasetFilterList,
   value,
   onChange,
   baseMapProps,
@@ -101,6 +103,7 @@ const MapComponent = ({
           <DatasetControl
             selectedDatasets={datasets}
             onSelectDataset={selectDataset}
+            datasetFilterList={datasetFilterList}
           />
         )}
       </div>

--- a/dluhc-component-library/src/components/maps/components/DatasetControl.tsx
+++ b/dluhc-component-library/src/components/maps/components/DatasetControl.tsx
@@ -1,21 +1,38 @@
+import { useMemo } from "preact/hooks";
 import { useFetchDatasets } from "src/api/planningData/api";
 import DatasetList from "src/components/datasets/DatasetList";
 
 interface DatasetControlProps {
   selectedDatasets: ReadonlyArray<string>;
+  datasetFilterList?: ReadonlyArray<string>;
   onSelectDataset: (dataset: string) => void;
 }
 
 const DatasetControl = ({
   selectedDatasets,
+  datasetFilterList,
   onSelectDataset,
 }: DatasetControlProps) => {
   const { data: datasets, isLoading } = useFetchDatasets();
 
+  const filteredDatasets = useMemo(() => {
+    if (!datasets) {
+      return [];
+    }
+
+    if (datasetFilterList && datasetFilterList.length) {
+      return datasets.filter((dataset) =>
+        datasetFilterList.includes(dataset.dataset),
+      );
+    }
+
+    return datasets;
+  }, [datasetFilterList, datasets]);
+
   return (
     <div className="dataset-control">
       <DatasetList
-        items={datasets || []}
+        items={filteredDatasets}
         selectedItems={selectedDatasets}
         onSelect={onSelectDataset}
         isLoading={isLoading}

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -32,7 +32,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
     [value],
   );
 
-  const { data: riskData, isFetching } = useFetchEntities(polygon);
+  const { data: riskData, isLoading } = useFetchEntities(polygon);
 
   const activeRisks = useMemo(
     () =>
@@ -48,7 +48,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
     [riskData],
   );
 
-  const hasRisks = value && !isFetching && !!activeRisks?.length;
+  const hasRisks = value && !isLoading && !!activeRisks?.length;
 
   return (
     <div className="flex flex-col mb-4">
@@ -59,6 +59,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
       <MapComponent
         className="my-4"
         style={{ height: "470px", width: "100%" }}
+        datasetFilterList={RISKS}
         value={value}
         onChange={onChange}
       />
@@ -107,7 +108,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
         touch if we have any questions about where the boundary line is intended
         to be.
       </p>
-      {isFetching && <p className="my-8">Loading...</p>}
+      {isLoading && <p className="my-8">Loading...</p>}
       {hasRisks && (
         <>
           <h2 className="my-4 text-3xl font-bold">


### PR DESCRIPTION
Adds a new prop to the map component that allows the user to filter the list of shown datasets.

![image](https://github.com/digital-land/plan-making/assets/97245023/b9f56092-c2ba-406f-a4d3-209f9b62acbf)