### PR TITLE
DLUHC-176 Add basic loading spinner to map page

### DIFF
--- a/dluhc-component-library/src/components/loadingSpinner/LoadingSpinner.css
+++ b/dluhc-component-library/src/components/loadingSpinner/LoadingSpinner.css
@@ -1,0 +1,19 @@
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #000;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/dluhc-component-library/src/components/loadingSpinner/LoadingSpinner.tsx
+++ b/dluhc-component-library/src/components/loadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,15 @@
+import "./LoadingSpinner.css";
+
+interface LoadingSpinnerProps {
+  className?: string;
+}
+
+const LoadingSpinner = ({ className }: LoadingSpinnerProps) => {
+  return (
+    <div className={className}>
+      <span class="loading-spinner" />
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/MapPage.tsx
@@ -2,6 +2,7 @@ import { Polygon } from "ol/geom";
 import { useMemo } from "preact/hooks";
 import { useFetchEntities } from "src/api/planningData/api";
 import AccordionDropdown from "src/components/accordianDropdown/AccordionDropdown";
+import LoadingSpinner from "src/components/loadingSpinner/LoadingSpinner";
 import MapComponent from "src/components/maps/MapComponent";
 import { Boundary } from "src/components/maps/types";
 
@@ -108,7 +109,7 @@ const MapPage = ({ value, onChange }: MapPageProps) => {
         touch if we have any questions about where the boundary line is intended
         to be.
       </p>
-      {isLoading && <p className="my-8">Loading...</p>}
+      {isLoading && <LoadingSpinner className="my-4" />}
       {hasRisks && (
         <>
           <h2 className="my-4 text-3xl font-bold">


### PR DESCRIPTION
Adds a basic loading spinner component and adds it to the map page instead of the loading text

![image](https://github.com/digital-land/plan-making/assets/97245023/f9e8c6d5-04db-43cf-b3c9-993d837cab8f)
