### PR TITLE
add Dluhc 201 timetable form styling

### DIFF
--- a/dluhc-component-library/src/components/formComponents/dateInput/DateInput.tsx
+++ b/dluhc-component-library/src/components/formComponents/dateInput/DateInput.tsx
@@ -1,19 +1,28 @@
 const DateInput = () => {
   return (
-    <div>
-      <label>
-        Day
-        <input type="text" className="border-2 border-black w-10" />
+    <div className="flex mb-4">
+      <label className="mr-2">
+        <p>Day</p>
+        <input
+          type="text"
+          className="border-2 border-black w-10 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
+        />
       </label>
 
-      <label>
-        Month
-        <input type="text" className="border-2 border-black w-10" />
+      <label className="mx-2">
+        <p>Month</p>
+        <input
+          type="text"
+          className="border-2 border-black w-10 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
+        />
       </label>
 
-      <label>
-        Year
-        <input type="text" className="border-2 border-black w-20" />
+      <label className="mx-2">
+        <p>Year</p>
+        <input
+          type="text"
+          className="border-2 border-black w-20 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
+        />
       </label>
     </div>
   );

--- a/dluhc-component-library/src/components/formComponents/input/Input.tsx
+++ b/dluhc-component-library/src/components/formComponents/input/Input.tsx
@@ -24,7 +24,7 @@ const Input = <T extends number | string>({
       <label className="font-semibold flex">
         <input
           type={type}
-          class="text mr-2 border-2 border-black py-1 px-2"
+          class="text mr-2 border-2 border-black py-1 px-2 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
           value={value}
           onChange={(event) => handleChange(event.currentTarget.value)}
           step={step}

--- a/dluhc-component-library/src/components/formComponents/textarea/Textarea.tsx
+++ b/dluhc-component-library/src/components/formComponents/textarea/Textarea.tsx
@@ -11,10 +11,12 @@ const Textarea = ({ value, onChange, maxLength }: TextareaProps) => {
         value={value}
         onChange={(event) => onChange(event.currentTarget.value)}
         maxLength={maxLength}
-        className="border-2 border-black"
+        className="border-2 border-black w-8/12 h-32 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
       />
       {maxLength && (
-        <p>You have {maxLength - value.length} characters remaining</p>
+        <p className="text-sm mb-8 text-gray-600">
+          You have {maxLength - value.length} characters remaining
+        </p>
       )}
     </div>
   );

--- a/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
+++ b/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
@@ -28,12 +28,15 @@ const TimetableForm = () => {
 
   return (
     <div>
-      <button
-        className="bg-gray-200 hover:bg-gray-300 py-1 px-2"
-        onClick={handleBackClicked}
-      >
-        Back
-      </button>
+      <div>
+        &lt;
+        <p
+          className="underline hover:decoration-2 py-1 px-2 inline-block cursor-pointer"
+          onClick={handleBackClicked}
+        >
+          Back
+        </p>
+      </div>
       <div>{page && <page.component />}</div>
       <button
         className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"

--- a/dluhc-component-library/src/components/timetableForm/components/DescriptionPage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/DescriptionPage.tsx
@@ -3,8 +3,10 @@ import { Textarea } from "src/components/formComponents";
 const DescriptionPage = () => {
   return (
     <div className="flex flex-col">
-      <h1 className="my-2 text-4xl font-bold">Summary text</h1>
-      <p>Keep this specific to your own Local Plan</p>
+      <h1 className="my-6 text-3xl font-bold">Summary text</h1>
+      <p className="text-sm mb-2 text-gray-600">
+        Keep this specific to your own Local Plan
+      </p>
       <Textarea value="" onChange={() => {}} maxLength={400} />
     </div>
   );

--- a/dluhc-component-library/src/components/timetableForm/components/PublishedDatePage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/PublishedDatePage.tsx
@@ -3,12 +3,12 @@ import { DateInput } from "src/components/formComponents";
 const PublishedDatePage = () => {
   return (
     <div className="flex flex-col">
-      <h1 className="my-2 text-4xl font-bold">Timetable published date</h1>
-      <p>
+      <h1 className="my-6 text-3xl font-bold">Timetable published date</h1>
+      <p className="w-1/2">
         This is the date this version of your timetable will be published
         publicly online
       </p>
-      <p>For example, 21 3 2025</p>
+      <p className="text-sm mt-4 mb-2 text-gray-600">For example, 21 3 2025</p>
       <DateInput />
     </div>
   );

--- a/dluhc-component-library/src/components/timetableForm/components/TitlePage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/TitlePage.tsx
@@ -3,8 +3,10 @@ import { Textarea } from "src/components/formComponents";
 const TitlePage = () => {
   return (
     <div className="flex flex-col">
-      <h1 className="my-2 text-4xl font-bold">Local Plan title</h1>
-      <p>Such as Birmingham City 2025-2040 Local Plan timetable</p>
+      <h1 className="my-6 text-3xl font-bold">Local Plan title</h1>
+      <p className="text-sm mb-2 text-gray-600">
+        Such as Birmingham City 2025-2040 Local Plan timetable
+      </p>
       <Textarea value="" onChange={() => {}} maxLength={100} />
     </div>
   );


### PR DESCRIPTION
added styling for the timetbale form component.
followed these references:
https://www.figma.com/file/XaBQCco5EI92PaBDXq7Mqq/DLUHC-New-Local-Plans-timetable-dashboard-concepts?type=design&node-id=0-1&mode=design
https://design-system.service.gov.uk/components/

![image](https://github.com/digital-land/plan-making/assets/110818566/66b82f89-bc96-4df0-a28a-50142450fea1)
![image](https://github.com/digital-land/plan-making/assets/110818566/aea6ba80-b4e7-4d0e-bfa5-dcf7f93482aa)


