### PR TITLE
DLUHC-203 Add basic policy form

### DIFF
--- a/dluhc-component-library/src/components/formComponents/input/Input.tsx
+++ b/dluhc-component-library/src/components/formComponents/input/Input.tsx
@@ -1,9 +1,10 @@
 interface InputProps<T> {
   value: T;
-  type: string;
+  type?: string;
   step?: string;
   min?: string;
   max?: string;
+  label?: string;
   onChange: (value: T) => void;
 }
 
@@ -13,6 +14,7 @@ const Input = <T extends number | string>({
   step,
   min,
   max,
+  label,
   onChange,
 }: InputProps<T>) => {
   const handleChange = (value: string) => {
@@ -21,10 +23,11 @@ const Input = <T extends number | string>({
 
   const InputBox = (
     <div className="flex items-center my-8">
-      <label className="font-semibold flex">
+      <label className="flex text-2xl font-bold flex-col">
+        {label}
         <input
           type={type}
-          class="text mr-2 border-2 border-black py-1 px-2 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
+          class="font-semibold text-base text mr-2 border-2 border-black py-1 px-2 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
           value={value}
           onChange={(event) => handleChange(event.currentTarget.value)}
           step={step}

--- a/dluhc-component-library/src/components/formComponents/textarea/Textarea.tsx
+++ b/dluhc-component-library/src/components/formComponents/textarea/Textarea.tsx
@@ -1,18 +1,29 @@
 interface TextareaProps {
   value: string;
-  onChange: (value: string) => void;
   maxLength?: number;
+  label?: string;
+  className?: string;
+  onChange: (value: string) => void;
 }
 
-const Textarea = ({ value, onChange, maxLength }: TextareaProps) => {
+const Textarea = ({
+  value,
+  maxLength,
+  label,
+  className,
+  onChange,
+}: TextareaProps) => {
   return (
-    <div>
-      <textarea
-        value={value}
-        onChange={(event) => onChange(event.currentTarget.value)}
-        maxLength={maxLength}
-        className="border-2 border-black w-8/12 h-32 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
-      />
+    <div className={className}>
+      <label className="flex text-2xl font-bold flex-col">
+        {label}
+        <textarea
+          value={value}
+          onChange={(event) => onChange(event.currentTarget.value)}
+          maxLength={maxLength}
+          className="font-semibold text-base border-2 border-black w-8/12 h-32 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
+        />
+      </label>
       {maxLength && (
         <p className="text-sm mb-8 text-gray-600">
           You have {maxLength - value.length} characters remaining

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -1,35 +1,15 @@
 import { useState } from "preact/hooks";
 import { Input, Textarea } from "../formComponents";
 import MapComponent from "../maps/MapComponent";
-import { Boundary } from "../maps/types";
-
-const TITLE_KEY = "title";
-const DESCRIPTION_KEY = "description";
-const REQUIREMENTS = "requirements";
-const BOUNDARY_KEY = "boundary";
-
-interface FormState {
-  [TITLE_KEY]: string;
-  [DESCRIPTION_KEY]: string;
-  [REQUIREMENTS]: string;
-  [BOUNDARY_KEY]: Boundary;
-}
-
-type FormValue = string | Boundary;
-
-const FORM_lABELS = {
-  [TITLE_KEY]: "Title",
-  [DESCRIPTION_KEY]: "Description",
-  [REQUIREMENTS]: "Requirements",
-  [BOUNDARY_KEY]: "Draw a boundary",
-};
-
-const INITIAL_FORM_STATE: FormState = {
-  [TITLE_KEY]: "",
-  [DESCRIPTION_KEY]: "",
-  [REQUIREMENTS]: "",
-  [BOUNDARY_KEY]: [],
-};
+import {
+  BOUNDARY_KEY,
+  DESCRIPTION_KEY,
+  FORM_lABELS,
+  INITIAL_FORM_STATE,
+  REQUIREMENTS,
+  TITLE_KEY,
+} from "./constants";
+import { FormState, FormValue } from "./types";
 
 const PolicyForm = () => {
   const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -1,0 +1,95 @@
+import { useState } from "preact/hooks";
+import { Input, Textarea } from "../formComponents";
+import MapComponent from "../maps/MapComponent";
+import { Boundary } from "../maps/types";
+
+const TITLE_KEY = "title";
+const DESCRIPTION_KEY = "description";
+const REQUIREMENTS = "requirements";
+const BOUNDARY_KEY = "boundary";
+
+interface FormState {
+  [TITLE_KEY]: string;
+  [DESCRIPTION_KEY]: string;
+  [REQUIREMENTS]: string;
+  [BOUNDARY_KEY]: Boundary;
+}
+
+type FormValue = string | Boundary;
+
+const FORM_lABELS = {
+  [TITLE_KEY]: "Title",
+  [DESCRIPTION_KEY]: "Description",
+  [REQUIREMENTS]: "Requirements",
+  [BOUNDARY_KEY]: "Draw a boundary",
+};
+
+const INITIAL_FORM_STATE: FormState = {
+  [TITLE_KEY]: "",
+  [DESCRIPTION_KEY]: "",
+  [REQUIREMENTS]: "",
+  [BOUNDARY_KEY]: [],
+};
+
+const PolicyForm = () => {
+  const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
+
+  const handleValueChange = (key: string, value: FormValue) => {
+    setFormState({
+      ...formState,
+      [key]: value,
+    });
+  };
+
+  const handleSaveClicked = () => {
+    console.log(formState);
+  };
+
+  return (
+    <div>
+      <h1 className="my-2 text-4xl font-bold">Create a Policy</h1>
+      <Input
+        label={FORM_lABELS[TITLE_KEY]}
+        value={formState[TITLE_KEY]}
+        onChange={(value) => handleValueChange(TITLE_KEY, value)}
+      />
+
+      <Textarea
+        label={FORM_lABELS[DESCRIPTION_KEY]}
+        className="my-4"
+        value={formState[DESCRIPTION_KEY]}
+        onChange={(value) => handleValueChange(DESCRIPTION_KEY, value)}
+        maxLength={350}
+      />
+
+      <Textarea
+        label={FORM_lABELS[REQUIREMENTS]}
+        className="my-4"
+        value={formState[REQUIREMENTS]}
+        onChange={(value) => handleValueChange(REQUIREMENTS, value)}
+      />
+
+      <div className="my-4">
+        <label className="text-2xl font-bold">
+          {FORM_lABELS[BOUNDARY_KEY]}
+        </label>
+        <MapComponent
+          className="my-1"
+          style={{ height: "470px", width: "100%" }}
+          showDatasets={false}
+          value={formState[BOUNDARY_KEY]}
+          onChange={(value) => handleValueChange(BOUNDARY_KEY, value)}
+        />
+      </div>
+
+      <button
+        className="mt-8 bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+        onClick={handleSaveClicked}
+      >
+        Save
+      </button>
+    </div>
+  );
+};
+
+export default PolicyForm;

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -14,7 +14,7 @@ import { FormState, FormValue } from "./types";
 const PolicyForm = () => {
   const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
 
-  const handleValueChange = (key: string, value: FormValue) => {
+  const handleValueChange = (key: keyof FormState, value: FormValue) => {
     setFormState({
       ...formState,
       [key]: value,

--- a/dluhc-component-library/src/components/policyForm/constants.ts
+++ b/dluhc-component-library/src/components/policyForm/constants.ts
@@ -1,0 +1,20 @@
+import { FormState } from "./types";
+
+export const TITLE_KEY = "title";
+export const DESCRIPTION_KEY = "description";
+export const REQUIREMENTS = "requirements";
+export const BOUNDARY_KEY = "boundary";
+
+export const FORM_lABELS = {
+  [TITLE_KEY]: "Title",
+  [DESCRIPTION_KEY]: "Description",
+  [REQUIREMENTS]: "Requirements",
+  [BOUNDARY_KEY]: "Draw a boundary",
+};
+
+export const INITIAL_FORM_STATE: FormState = {
+  [TITLE_KEY]: "",
+  [DESCRIPTION_KEY]: "",
+  [REQUIREMENTS]: "",
+  [BOUNDARY_KEY]: [],
+};

--- a/dluhc-component-library/src/components/policyForm/types.ts
+++ b/dluhc-component-library/src/components/policyForm/types.ts
@@ -1,0 +1,15 @@
+import {
+  BOUNDARY_KEY,
+  DESCRIPTION_KEY,
+  REQUIREMENTS,
+  TITLE_KEY,
+} from "./constants";
+
+export interface FormState {
+  [TITLE_KEY]: string;
+  [DESCRIPTION_KEY]: string;
+  [REQUIREMENTS]: string;
+  [BOUNDARY_KEY]: Boundary;
+}
+
+export type FormValue = string | Boundary;

--- a/dluhc-component-library/src/stories/PolicyForm.stories.tsx
+++ b/dluhc-component-library/src/stories/PolicyForm.stories.tsx
@@ -1,0 +1,11 @@
+import PolicyForm from "src/components/policyForm/PolicyForm";
+
+export default {
+  component: PolicyForm,
+  title: "SOW14/Policy Form",
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {},
+};


### PR DESCRIPTION
Adds the foundation for the policy form. I haven't been able to get hold of any wireframes yet so this is primarily just a guess by looking at existing policies.

I still need to add a multiselect for the themes the policy links to and potentially a way to link to other policies.

![image](https://github.com/digital-land/plan-making/assets/97245023/845142d1-71e1-4f0b-9b15-3f85f216decf)
