### PR TITLE
DLUHC-203 Update policy form to follow wireframe

### DIFF
--- a/dluhc-component-library/src/components/formComponents/input/Input.tsx
+++ b/dluhc-component-library/src/components/formComponents/input/Input.tsx
@@ -23,7 +23,7 @@ const Input = <T extends number | string>({
 
   const InputBox = (
     <div className="flex items-center my-8">
-      <label className="flex text-2xl font-bold flex-col">
+      <label className="flex text-xl font-bold flex-col">
         {label}
         <input
           type={type}

--- a/dluhc-component-library/src/components/formComponents/textarea/Textarea.tsx
+++ b/dluhc-component-library/src/components/formComponents/textarea/Textarea.tsx
@@ -15,7 +15,7 @@ const Textarea = ({
 }: TextareaProps) => {
   return (
     <div className={className}>
-      <label className="flex text-2xl font-bold flex-col">
+      <label className="flex text-xl font-bold flex-col">
         {label}
         <textarea
           value={value}

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -8,11 +8,13 @@ import {
   INITIAL_FORM_STATE,
   REFERENCE_KEY,
   REQUIREMENTS,
+  SUPPLEMENTARY_TEXT_KEY,
   THEMES_KEY,
   THEME_OPTIONS,
   TITLE_KEY,
 } from "./constants";
 import { FormState, FormValue } from "./types";
+import MultiItem from "./components/MultiItem";
 
 const PolicyForm = () => {
   const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
@@ -32,21 +34,10 @@ const PolicyForm = () => {
     <div>
       <h1 className="my-2 text-4xl font-bold">Create a Policy</h1>
       <form onSubmit={handleFormSubmit}>
-        <Input
-          label={FORM_lABELS[REFERENCE_KEY]}
-          value={formState[REFERENCE_KEY]}
-          onChange={(value) => handleValueChange(REFERENCE_KEY, value)}
-        />
+        <h2 className="my-8 text-3xl font-bold">Policy details</h2>
 
-        <Input
-          label={FORM_lABELS[TITLE_KEY]}
-          value={formState[TITLE_KEY]}
-          onChange={(value) => handleValueChange(TITLE_KEY, value)}
-        />
-        <div className="my-8">
-          <label className="text-2xl font-bold">
-            {FORM_lABELS[THEMES_KEY]}
-          </label>
+        <div className="my-4">
+          <label className="text-xl font-bold">{FORM_lABELS[THEMES_KEY]}</label>
           <MultiSelect
             className="mt-2"
             options={THEME_OPTIONS}
@@ -54,6 +45,20 @@ const PolicyForm = () => {
             onChange={(value) => handleValueChange(THEMES_KEY, value)}
           />
         </div>
+
+        <Input
+          label={FORM_lABELS[TITLE_KEY]}
+          value={formState[TITLE_KEY]}
+          onChange={(value) => handleValueChange(TITLE_KEY, value)}
+        />
+
+        <Input
+          label={FORM_lABELS[REFERENCE_KEY]}
+          value={formState[REFERENCE_KEY]}
+          onChange={(value) => handleValueChange(REFERENCE_KEY, value)}
+        />
+
+        <h2 className="my-2 text-3xl font-bold">Policy box</h2>
 
         <Textarea
           label={FORM_lABELS[DESCRIPTION_KEY]}
@@ -63,15 +68,16 @@ const PolicyForm = () => {
           maxLength={350}
         />
 
-        <Textarea
+        {/*time peroid*/}
+
+        <MultiItem
           label={FORM_lABELS[REQUIREMENTS]}
-          className="my-4"
-          value={formState[REQUIREMENTS]}
+          values={formState[REQUIREMENTS]}
           onChange={(value) => handleValueChange(REQUIREMENTS, value)}
         />
 
         <div className="my-4">
-          <label className="text-2xl font-bold">
+          <label className="text-xl font-bold">
             {FORM_lABELS[BOUNDARY_KEY]}
           </label>
           <MapComponent
@@ -82,6 +88,15 @@ const PolicyForm = () => {
             onChange={(value) => handleValueChange(BOUNDARY_KEY, value)}
           />
         </div>
+
+        <h2 className="my-2 text-3xl font-bold">Supplementary text</h2>
+
+        <Textarea
+          label={FORM_lABELS[SUPPLEMENTARY_TEXT_KEY]}
+          className="my-4"
+          value={formState[SUPPLEMENTARY_TEXT_KEY]}
+          onChange={(value) => handleValueChange(SUPPLEMENTARY_TEXT_KEY, value)}
+        />
 
         <button className="mt-8 bg-green-700 hover:bg-green-800 text-white py-1 px-2">
           Save

--- a/dluhc-component-library/src/components/policyForm/components/MultiItem.tsx
+++ b/dluhc-component-library/src/components/policyForm/components/MultiItem.tsx
@@ -1,0 +1,74 @@
+interface MultiItemProps {
+  label?: string;
+  values?: ReadonlyArray<string>;
+  className?: string;
+  onChange: (values: ReadonlyArray<string>) => void;
+}
+
+const MultiItem = ({
+  label,
+  values = [],
+  className,
+  onChange,
+}: MultiItemProps) => {
+  const handleValueChange = (index: number, newValue: string) => {
+    let newState = [...values];
+
+    newState[index] = newValue;
+
+    onChange(newState);
+  };
+
+  const handleAddClicked = () => {
+    onChange([...values, ""]);
+  };
+
+  const handleDeleteClicked = (index: number) => {
+    const newState = [...values];
+
+    newState.splice(index, 1);
+
+    onChange(newState);
+  };
+
+  const inputs = values.map((value, index) => {
+    return (
+      <div className="flex flex-row my-4">
+        <p className="flex flex-col justify-center pr-2 font-bold">{`${index}.`}</p>
+        <input
+          type="string"
+          class="font-semibold text-base text mr-2 border-2 border-black py-1 px-2 focus:outline-offset-2 focus:outline-2 focus:outline-yellow-400"
+          value={value}
+          onChange={(event) =>
+            handleValueChange(index, event.currentTarget.value)
+          }
+        />
+        <button
+          className="bg-red-700 hover:bg-red-800 text-white py-1 px-2"
+          type="button"
+          onClick={() => handleDeleteClicked(index)}
+        >
+          Delete
+        </button>
+      </div>
+    );
+  });
+
+  const parentClass = `my-4 align-middle ${className}`;
+
+  return (
+    <div className={parentClass}>
+      <label className="text-xl font-bold">{label}</label>
+      <div className="my-2">{inputs}</div>
+      <button
+        className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+        type="button"
+        onClick={handleAddClicked}
+      >
+        Add
+      </button>
+    </div>
+  );
+};
+
+export default MultiItem;

--- a/dluhc-component-library/src/components/policyForm/constants.ts
+++ b/dluhc-component-library/src/components/policyForm/constants.ts
@@ -6,23 +6,26 @@ export const DESCRIPTION_KEY = "description";
 export const REQUIREMENTS = "requirements";
 export const BOUNDARY_KEY = "boundary";
 export const THEMES_KEY = "themes";
+export const SUPPLEMENTARY_TEXT_KEY = "supplementaryText";
 
 export const FORM_lABELS = {
-  [REFERENCE_KEY]: "Reference",
-  [TITLE_KEY]: "Title",
+  [REFERENCE_KEY]: "Policy number (?)",
+  [TITLE_KEY]: "Policy Title (?)",
   [DESCRIPTION_KEY]: "Description",
   [REQUIREMENTS]: "Requirements",
   [BOUNDARY_KEY]: "Draw a boundary",
   [THEMES_KEY]: "Themes",
+  [SUPPLEMENTARY_TEXT_KEY]: "Text 1.1",
 };
 
 export const INITIAL_FORM_STATE: FormState = {
   [REFERENCE_KEY]: "",
   [TITLE_KEY]: "",
   [DESCRIPTION_KEY]: "",
-  [REQUIREMENTS]: "",
+  [REQUIREMENTS]: [""],
   [BOUNDARY_KEY]: [],
   [THEMES_KEY]: [],
+  [SUPPLEMENTARY_TEXT_KEY]: "",
 };
 
 export const THEME_OPTIONS = [

--- a/dluhc-component-library/src/components/policyForm/types.ts
+++ b/dluhc-component-library/src/components/policyForm/types.ts
@@ -4,6 +4,7 @@ import {
   DESCRIPTION_KEY,
   REFERENCE_KEY,
   REQUIREMENTS,
+  SUPPLEMENTARY_TEXT_KEY,
   THEMES_KEY,
   TITLE_KEY,
 } from "./constants";
@@ -12,9 +13,10 @@ export interface FormState {
   [REFERENCE_KEY]: string;
   [TITLE_KEY]: string;
   [DESCRIPTION_KEY]: string;
-  [REQUIREMENTS]: string;
+  [REQUIREMENTS]: ReadonlyArray<string>;
   [BOUNDARY_KEY]: Boundary;
   [THEMES_KEY]: ReadonlyArray<string>;
+  [SUPPLEMENTARY_TEXT_KEY]: string;
 }
 
 export type FormValue = FormState[keyof FormState];


### PR DESCRIPTION
Updated the form layout to follow the CMS wireframe format and questions.

This implementation is missing the time period section but that will be done in another PR.

The MultiItem component should also take a component to map over but for a first step it only works with base text inputs.

![image](https://github.com/digital-land/plan-making/assets/97245023/7a4e8a06-49be-468a-81f9-be1a13f2673d)

![image](https://github.com/digital-land/plan-making/assets/97245023/b5cd1830-d4d8-4164-aab0-c2e7b2273db1)