### PR TITLE
DLUHC-201 add download of timetable json

### DIFF
--- a/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
+++ b/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
@@ -1,10 +1,12 @@
 import { useState } from "preact/hooks";
 import DescriptionPage from "./components/DescriptionPage";
+import ExportPage from "./components/ExportPgae";
 import PublishedDatePage from "./components/PublishedDatePage";
 import StagePage from "./components/StagePage";
 import TitlePage from "./components/TitlePage";
 import {
   DESCRIPTION_KEY,
+  EXPORT_KEY,
   GATEWAY_1_KEY,
   INITIAL_STATE,
   PUBLISH_DATE_KEY,
@@ -13,7 +15,7 @@ import {
 } from "./constants";
 import { FormState, FormValue } from "./types";
 
-const TOTAL_PAGES = 5;
+const TOTAL_PAGES = 6;
 
 const renderPage = (
   key: string,
@@ -58,6 +60,8 @@ const renderPage = (
           onChange={(stage) => handleValueChange(key, stage)}
         />
       );
+    case EXPORT_KEY:
+      return <ExportPage value={value} />;
     default:
       return null;
   }
@@ -69,6 +73,7 @@ const FORM_KEY_LIST = [
   PUBLISH_DATE_KEY,
   SCOPING_KEY,
   GATEWAY_1_KEY,
+  EXPORT_KEY,
 ];
 
 const TimetableForm = () => {
@@ -107,12 +112,14 @@ const TimetableForm = () => {
         </p>
       </div>
       <div>{Page}</div>
-      <button
-        className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"
-        onClick={handleContinueClicked}
-      >
-        Continue
-      </button>
+      {currentPage !== EXPORT_KEY && (
+        <button
+          className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+          onClick={handleContinueClicked}
+        >
+          Continue
+        </button>
+      )}
     </div>
   );
 };

--- a/dluhc-component-library/src/components/timetableForm/components/ExportPgae.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/ExportPgae.tsx
@@ -1,0 +1,34 @@
+import { FormState } from "../types";
+import { getTimetableDownload } from "../utils";
+
+interface ExportPageProps {
+  value: FormState;
+}
+
+const ExportPage = ({ value }: ExportPageProps) => {
+  const downloadLink = getTimetableDownload(value);
+  return (
+    <div>
+      <h1 className="my-6 text-3xl font-bold">Export your timetable to JSON</h1>
+      <p className="w-2/3 mb-4">
+        When you have completed all the details, you can export your data into a
+        JSON file that can generate the DLUHC TImetable Template on your
+        website.
+      </p>
+      <p className="text-blue-400 underline mb-4">
+        Read more about how to publish Timetable JSON data online
+      </p>
+      <a
+        role="button"
+        type="button"
+        className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+        href={downloadLink}
+        download="timetabe.json"
+      >
+        Export Timetable JSON
+      </a>
+    </div>
+  );
+};
+
+export default ExportPage;

--- a/dluhc-component-library/src/components/timetableForm/components/StagePage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/StagePage.tsx
@@ -12,12 +12,12 @@ import {
   PROGRESS_TEXT_MAP,
 } from "src/models/timetable/constants";
 import { Progress } from "src/models/timetable/types";
-import { Stage } from "../types";
+import { FormStage } from "../types";
 
 interface StagePageProps {
   stageName: string;
-  value: Stage;
-  onChange: (value: Stage) => void;
+  value: FormStage;
+  onChange: (value: FormStage) => void;
 }
 
 const PROGRESS_OPTIONS: ReadonlyArray<RadioOption<string>> = [

--- a/dluhc-component-library/src/components/timetableForm/constants.ts
+++ b/dluhc-component-library/src/components/timetableForm/constants.ts
@@ -1,16 +1,17 @@
 import { NOT_STARTED } from "src/models/timetable/constants";
-import { FormState, Stage } from "./types";
 import { DateValue } from "../formComponents/dateInput/types";
+import { FormStage, FormState } from "./types";
 
 export const TITLE_KEY = "title";
 export const DESCRIPTION_KEY = "description";
 export const PUBLISH_DATE_KEY = "publishDate";
 export const SCOPING_KEY = "scoping";
 export const GATEWAY_1_KEY = "gateway1";
+export const EXPORT_KEY = "export";
 
 const DEFAULT_DATE: DateValue = { day: "", month: "", year: "" };
 
-const INITIAL_STAGE: Stage = {
+const INITIAL_STAGE: FormStage = {
   startDate: DEFAULT_DATE,
   endDate: DEFAULT_DATE,
   progress: NOT_STARTED,

--- a/dluhc-component-library/src/components/timetableForm/types.ts
+++ b/dluhc-component-library/src/components/timetableForm/types.ts
@@ -12,13 +12,13 @@ export interface FormState {
   [TITLE_KEY]: string;
   [DESCRIPTION_KEY]: string;
   [PUBLISH_DATE_KEY]: DateValue;
-  [SCOPING_KEY]: Stage;
-  [GATEWAY_1_KEY]: Stage;
+  [SCOPING_KEY]: FormStage;
+  [GATEWAY_1_KEY]: FormStage;
 }
 
-export type FormValue = String | DateValue | Stage;
+export type FormValue = String | DateValue | FormStage;
 
-export interface Stage {
+export interface FormStage {
   startDate: DateValue;
   endDate: DateValue;
   progress: Progress;

--- a/dluhc-component-library/src/components/timetableForm/utils.ts
+++ b/dluhc-component-library/src/components/timetableForm/utils.ts
@@ -1,0 +1,47 @@
+import { DateValue } from "src/components/formComponents/dateInput/types";
+import { FormState, FormStage } from "./types";
+import { Stage, Timetable } from "src/models/timetable/types";
+import { GATEWAY_1_KEY, SCOPING_KEY } from "./constants";
+
+export const getTimetableDownload = (formData: FormState) => {
+  const timetable = formatTimetableFormData(formData);
+  return `data:text/json;charset=urf-8, ${encodeURIComponent(
+    JSON.stringify(timetable),
+  )}`;
+};
+
+const formatTimetableFormData = (formData: FormState): Timetable => ({
+  title: formData.title,
+  description: formData.description,
+  publishDate: formatDateValue(formData.publishDate),
+  stages: [
+    formatStage(
+      SCOPING_KEY,
+      "Scoping and early participation",
+      formData[SCOPING_KEY],
+    ),
+    formatStage(
+      GATEWAY_1_KEY,
+      "Gateway 1. Check-point",
+      formData[GATEWAY_1_KEY],
+    ),
+  ],
+});
+
+const formatStage = (key: string, name: string, stage: FormStage): Stage => ({
+  key,
+  name,
+  startDate: formatDateValue(stage.startDate),
+  endDate: formatDateValue(stage.endDate),
+  progress: stage.progress,
+  additionalInformation: stage.additionalInformation,
+});
+
+const formatDateValue = (dateValue: DateValue) => {
+  const year = dateValue.year
+    ? parseInt(dateValue.year)
+    : new Date().getFullYear();
+  const month = dateValue.month ? parseInt(dateValue.month) - 1 : 0;
+  const day = dateValue.day ? parseInt(dateValue.day) : 1;
+  return new Date(year, month, day);
+};

--- a/dluhc-component-library/src/models/timetable/types.ts
+++ b/dluhc-component-library/src/models/timetable/types.ts
@@ -1,5 +1,21 @@
 import { NOT_STARTED, DELAYED, IN_PROGRESS, FINISHED } from "./constants";
 
+export interface Timetable {
+  title: string;
+  description: string;
+  publishDate: Date;
+  stages: ReadonlyArray<Stage>;
+}
+
+export interface Stage {
+  key: string;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  progress: Progress;
+  additionalInformation: string;
+}
+
 export type Progress =
   | typeof NOT_STARTED
   | typeof DELAYED


### PR DESCRIPTION
Added page to the end of the timetable form to download the timetable data as a JSON file.
- Added new `ExportPage`  which has a button to download the form data as JSON.
- File is called `timetable.json` and goes into the downloads folder.
- Added utility methods to convert form data to JSON data format.