### PR TITLE
DLUHC-201 upload timetable JSON into form

### DIFF
--- a/dluhc-component-library/plan-making/assets/newTimetable.json
+++ b/dluhc-component-library/plan-making/assets/newTimetable.json
@@ -1,7 +1,7 @@
 {
   "title": "Andy plan",
   "description": "Sick plan made by Andy",
-  "publishDate": "1992-12-23T00:00:00.000Z",
+  "publishDate": 725068800000,
   "updated": "",
   "status": "",
   "periodStartToEnd": "",
@@ -10,16 +10,16 @@
     {
       "key": "scoping",
       "name": "Scoping and early participation",
-      "startDate": "2002-02-01T00:00:00.000Z",
-      "endDate": "2025-11-01T00:00:00.000Z",
+      "startDate": 1012521600000,
+      "endDate": 1761955200000,
       "progress": "inProgress",
       "additionalInformation": "Additional info"
     },
     {
       "key": "gateway1",
       "name": "Gateway 1. Check-point",
-      "startDate": "2024-04-30T23:00:00.000Z",
-      "endDate": "2040-07-31T23:00:00.000Z",
+      "startDate": 1714518000000,
+      "endDate": 2227388400000,
       "progress": "notStarted",
       "additionalInformation": "Oops"
     }

--- a/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
+++ b/dluhc-component-library/src/components/timetableForm/TimetableForm.tsx
@@ -5,11 +5,11 @@ import PublishedDatePage from "./components/PublishedDatePage";
 import StagePage from "./components/StagePage";
 import TitlePage from "./components/TitlePage";
 import {
-  LANDING_KEY,
   DESCRIPTION_KEY,
   EXPORT_KEY,
   GATEWAY_1_KEY,
   INITIAL_STATE,
+  LANDING_KEY,
   PUBLISH_DATE_KEY,
   SCOPING_KEY,
   TITLE_KEY,
@@ -24,10 +24,16 @@ const renderPage = (
   value: FormState,
   handleValueChange: (key: keyof FormState, value: FormValue) => void,
   handleContinueClicked: () => void,
+  handleTimetableUpload: (value: FormState) => void,
 ) => {
   switch (key) {
     case LANDING_KEY:
-      return <LandingPage onContinueClick={() => handleContinueClicked()} />;
+      return (
+        <LandingPage
+          onContinueClick={handleContinueClicked}
+          onUploadTimetable={handleTimetableUpload}
+        />
+      );
     case TITLE_KEY:
       return (
         <TitlePage
@@ -99,9 +105,17 @@ const TimetableForm = () => {
   };
 
   const handleContinueClicked = () => {
+    if (currentPageIndex === 0) {
+      setData(INITIAL_STATE);
+    }
     if (currentPageIndex < TOTAL_PAGES - 1) {
       setCurrentPageIndex(currentPageIndex + 1);
     }
+  };
+
+  const handleTimetableUpload = (value: FormState) => {
+    setData(value);
+    setCurrentPageIndex(currentPageIndex + 1);
   };
 
   const Page = renderPage(
@@ -109,6 +123,7 @@ const TimetableForm = () => {
     data,
     handleValueChange,
     handleContinueClicked,
+    handleTimetableUpload,
   );
 
   return (

--- a/dluhc-component-library/src/components/timetableForm/components/LandingPage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/LandingPage.tsx
@@ -6,17 +6,23 @@ interface LandingPageProps {
   onUploadTimetable: (value: FormState) => void;
 }
 
+const readTimetable = async (files: FileList | null) => {
+  if (!files || files.length === 0) {
+    return;
+  }
+  const url = URL.createObjectURL(files[0]);
+  return await loadTimetable(url);
+};
+
 const LandingPage = ({
   onContinueClick,
   onUploadTimetable,
 }: LandingPageProps) => {
-  const onUpload = async (files: FileList | null) => {
-    if (!files || files.length === 0) {
-      return;
+  const handleUpload = async (files: FileList | null) => {
+    const timetable = await readTimetable(files);
+    if (timetable) {
+      onUploadTimetable(timetable);
     }
-    const url = URL.createObjectURL(files[0]);
-    const formData = await loadTimetable(url);
-    return onUploadTimetable(formData);
   };
 
   return (
@@ -50,7 +56,7 @@ const LandingPage = ({
             hidden
             type="file"
             accept="text/json"
-            onChange={(event) => onUpload(event.currentTarget.files)}
+            onChange={(event) => handleUpload(event.currentTarget.files)}
           />
         </label>
       </div>

--- a/dluhc-component-library/src/components/timetableForm/components/LandingPage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/LandingPage.tsx
@@ -1,8 +1,15 @@
+import { FormState } from "../types";
+import { loadTimetable } from "../utils";
+
 interface LandingPageProps {
   onContinueClick: () => void;
+  onUploadTimetable: (value: FormState) => void;
 }
 
-const LandingPage = ({ onContinueClick }: LandingPageProps) => {
+const LandingPage = ({
+  onContinueClick,
+  onUploadTimetable,
+}: LandingPageProps) => {
   return (
     <div className="flex flex-col">
       <h1 className="my-6 text-3xl font-bold">
@@ -24,9 +31,27 @@ const LandingPage = ({ onContinueClick }: LandingPageProps) => {
         </button>
       </div>
       <div>
-        <button className="bg-green-700 hover:bg-green-800 text-white py-1 px-2">
+        <label
+          type="button"
+          role="button"
+          className="bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+        >
           Upload and edit an exisiting timetable
-        </button>
+          <input
+            hidden
+            type="file"
+            accept="text/json"
+            onChange={async (event) => {
+              const files = event.currentTarget.files;
+              if (!files || files.length === 0) {
+                return;
+              }
+              const url = URL.createObjectURL(files[0]);
+              const formData = await loadTimetable(url);
+              return onUploadTimetable(formData);
+            }}
+          />
+        </label>
       </div>
     </div>
   );

--- a/dluhc-component-library/src/components/timetableForm/components/LandingPage.tsx
+++ b/dluhc-component-library/src/components/timetableForm/components/LandingPage.tsx
@@ -10,6 +10,15 @@ const LandingPage = ({
   onContinueClick,
   onUploadTimetable,
 }: LandingPageProps) => {
+  const onUpload = async (files: FileList | null) => {
+    if (!files || files.length === 0) {
+      return;
+    }
+    const url = URL.createObjectURL(files[0]);
+    const formData = await loadTimetable(url);
+    return onUploadTimetable(formData);
+  };
+
   return (
     <div className="flex flex-col">
       <h1 className="my-6 text-3xl font-bold">
@@ -41,15 +50,7 @@ const LandingPage = ({
             hidden
             type="file"
             accept="text/json"
-            onChange={async (event) => {
-              const files = event.currentTarget.files;
-              if (!files || files.length === 0) {
-                return;
-              }
-              const url = URL.createObjectURL(files[0]);
-              const formData = await loadTimetable(url);
-              return onUploadTimetable(formData);
-            }}
+            onChange={(event) => onUpload(event.currentTarget.files)}
           />
         </label>
       </div>

--- a/dluhc-component-library/src/components/timetableForm/constants.ts
+++ b/dluhc-component-library/src/components/timetableForm/constants.ts
@@ -12,7 +12,7 @@ export const EXPORT_KEY = "export";
 
 const DEFAULT_DATE: DateValue = { day: "", month: "", year: "" };
 
-const INITIAL_STAGE: FormStage = {
+export const INITIAL_STAGE: FormStage = {
   startDate: DEFAULT_DATE,
   endDate: DEFAULT_DATE,
   progress: NOT_STARTED,

--- a/dluhc-component-library/src/components/timetableForm/utils.ts
+++ b/dluhc-component-library/src/components/timetableForm/utils.ts
@@ -1,13 +1,55 @@
 import { DateValue } from "src/components/formComponents/dateInput/types";
 import { FormState, FormStage } from "./types";
 import { Stage, TimetableData } from "src/models/timetable/types";
-import { GATEWAY_1_KEY, SCOPING_KEY } from "./constants";
+import {
+  DESCRIPTION_KEY,
+  GATEWAY_1_KEY,
+  INITIAL_STAGE,
+  PUBLISH_DATE_KEY,
+  SCOPING_KEY,
+  TITLE_KEY,
+} from "./constants";
 
 export const getTimetableDownload = (formData: FormState) => {
   const timetable = formatTimetableFormData(formData);
   return `data:text/json;charset=urf-8, ${encodeURIComponent(
     JSON.stringify(timetable),
   )}`;
+};
+
+export const loadTimetable = async (url: string): Promise<FormState> => {
+  return fetch(url)
+    .then((res) => res.json())
+    .then((data) => formatTimetableData(data));
+};
+
+const formatTimetableData = (timetable: TimetableData): FormState => ({
+  [TITLE_KEY]: timetable.title,
+  [DESCRIPTION_KEY]: timetable.description,
+  [PUBLISH_DATE_KEY]: formatDate(timetable.publishDate),
+  [SCOPING_KEY]: findAndFormatStage(SCOPING_KEY, timetable.stages),
+  [GATEWAY_1_KEY]: findAndFormatStage(GATEWAY_1_KEY, timetable.stages),
+});
+
+const findAndFormatStage = (key: string, stages: Stage[]): FormStage => {
+  const stage = stages.find((stage) => stage.key === key);
+  return stage ? formatStage(stage) : INITIAL_STAGE;
+};
+
+const formatStage = (stage: Stage): FormStage => ({
+  startDate: formatDate(stage.startDate),
+  endDate: formatDate(stage.endDate),
+  progress: stage.progress,
+  additionalInformation: stage.additionalInformation,
+});
+
+const formatDate = (date: Date): DateValue => {
+  const copy = new Date(date);
+  return {
+    day: copy.getDate().toString(),
+    month: (copy.getMonth() + 1).toString(),
+    year: copy.getFullYear().toString(),
+  };
 };
 
 const formatTimetableFormData = (formData: FormState): TimetableData => ({
@@ -19,12 +61,12 @@ const formatTimetableFormData = (formData: FormState): TimetableData => ({
   periodStartToEnd: "",
   coverage: "",
   stages: [
-    formatStage(
+    formatFormStage(
       SCOPING_KEY,
       "Scoping and early participation",
       formData[SCOPING_KEY],
     ),
-    formatStage(
+    formatFormStage(
       GATEWAY_1_KEY,
       "Gateway 1. Check-point",
       formData[GATEWAY_1_KEY],
@@ -32,7 +74,11 @@ const formatTimetableFormData = (formData: FormState): TimetableData => ({
   ],
 });
 
-const formatStage = (key: string, name: string, stage: FormStage): Stage => ({
+const formatFormStage = (
+  key: string,
+  name: string,
+  stage: FormStage,
+): Stage => ({
   key,
   name,
   startDate: formatDateValue(stage.startDate),

--- a/dluhc-component-library/src/components/timetableForm/utils.ts
+++ b/dluhc-component-library/src/components/timetableForm/utils.ts
@@ -2,12 +2,10 @@ import { DateValue } from "src/components/formComponents/dateInput/types";
 import { FormState, FormStage } from "./types";
 import { Stage, TimetableData } from "src/models/timetable/types";
 import {
-  DESCRIPTION_KEY,
   GATEWAY_1_KEY,
   INITIAL_STAGE,
   PUBLISH_DATE_KEY,
   SCOPING_KEY,
-  TITLE_KEY,
 } from "./constants";
 import { loadJson } from "src/utils";
 
@@ -23,8 +21,7 @@ export const loadTimetable = async (url: string): Promise<FormState> => {
 };
 
 const formatTimetableData = (timetable: TimetableData): FormState => ({
-  [TITLE_KEY]: timetable.title,
-  [DESCRIPTION_KEY]: timetable.description,
+  ...timetable,
   [PUBLISH_DATE_KEY]: formatDate(timetable.publishDate),
   [SCOPING_KEY]: findAndFormatStage(SCOPING_KEY, timetable.stages),
   [GATEWAY_1_KEY]: findAndFormatStage(GATEWAY_1_KEY, timetable.stages),
@@ -36,10 +33,9 @@ const findAndFormatStage = (key: string, stages: Stage[]): FormStage => {
 };
 
 const formatStage = (stage: Stage): FormStage => ({
+  ...stage,
   startDate: formatDate(stage.startDate),
   endDate: formatDate(stage.endDate),
-  progress: stage.progress,
-  additionalInformation: stage.additionalInformation,
 });
 
 const formatDate = (timestamp: number): DateValue => {

--- a/dluhc-component-library/src/components/timetableForm/utils.ts
+++ b/dluhc-component-library/src/components/timetableForm/utils.ts
@@ -9,6 +9,7 @@ import {
   SCOPING_KEY,
   TITLE_KEY,
 } from "./constants";
+import { loadJson } from "src/utils";
 
 export const getTimetableDownload = (formData: FormState) => {
   const timetable = formatTimetableFormData(formData);
@@ -18,9 +19,7 @@ export const getTimetableDownload = (formData: FormState) => {
 };
 
 export const loadTimetable = async (url: string): Promise<FormState> => {
-  return fetch(url)
-    .then((res) => res.json())
-    .then((data) => formatTimetableData(data));
+  return loadJson(url).then((data) => formatTimetableData(data));
 };
 
 const formatTimetableData = (timetable: TimetableData): FormState => ({

--- a/dluhc-component-library/src/components/timetableForm/utils.ts
+++ b/dluhc-component-library/src/components/timetableForm/utils.ts
@@ -43,12 +43,12 @@ const formatStage = (stage: Stage): FormStage => ({
   additionalInformation: stage.additionalInformation,
 });
 
-const formatDate = (date: Date): DateValue => {
-  const copy = new Date(date);
+const formatDate = (timestamp: number): DateValue => {
+  const date = new Date(timestamp);
   return {
-    day: copy.getDate().toString(),
-    month: (copy.getMonth() + 1).toString(),
-    year: copy.getFullYear().toString(),
+    day: date.getDate().toString(),
+    month: (date.getMonth() + 1).toString(),
+    year: date.getFullYear().toString(),
   };
 };
 
@@ -93,5 +93,5 @@ const formatDateValue = (dateValue: DateValue) => {
     : new Date().getFullYear();
   const month = dateValue.month ? parseInt(dateValue.month) - 1 : 0;
   const day = dateValue.day ? parseInt(dateValue.day) : 1;
-  return new Date(year, month, day);
+  return new Date(year, month, day).getTime();
 };

--- a/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
+++ b/dluhc-component-library/src/components/timetablePage/TimetablePage.tsx
@@ -13,7 +13,7 @@ interface TimetablePageProps {
 const DEFAULT_TIMETABLE_DATA: TimetableData = {
   title: "",
   description: "",
-  publishDate: new Date(),
+  publishDate: new Date().getTime(),
   updated: "",
   status: "",
   periodStartToEnd: "",

--- a/dluhc-component-library/src/models/timetable/types.ts
+++ b/dluhc-component-library/src/models/timetable/types.ts
@@ -3,7 +3,7 @@ import { NOT_STARTED, DELAYED, IN_PROGRESS, FINISHED } from "./constants";
 export interface TimetableData {
   title: string;
   description: string;
-  publishDate: Date;
+  publishDate: number;
   updated: string;
   status: string;
   periodStartToEnd: string;
@@ -14,8 +14,8 @@ export interface TimetableData {
 export interface Stage {
   key: string;
   name: string;
-  startDate: Date;
-  endDate: Date;
+  startDate: number;
+  endDate: number;
   progress: Progress;
   additionalInformation: string;
 }


### PR DESCRIPTION
Added functionality to timetable landing page to upload an existing timetable into the form.
- Added file type input and styled to look like a button.
- Added utils to convert between JSON representation of a timetable and form representation.
- Changed date type in JSON to be a number so it can be parsed more easily.