### PR TITLE
Add Policy form visualization

### DIFF
--- a/dluhc-component-library/plan-making/assets/policy.json
+++ b/dluhc-component-library/plan-making/assets/policy.json
@@ -1,0 +1,17 @@
+{
+  "reference": "1234",
+  "title": "test policy title",
+  "description": "this is a test policy",
+  "requirements": ["req1", "req2", "req3"],
+  "boundary": [
+    [
+      [-1.8299011230468751, 55.08256539731093],
+      [-1.9205383300781251, 55.0251414435385],
+      [-1.6980651855468751, 55.0251414435385],
+      [-1.6884521484375001, 55.06762736453004],
+      [-1.8299011230468751, 55.08256539731093]
+    ]
+  ],
+  "themes": ["artsCultureHeritage"],
+  "supplementaryText": "extra text for the policy"
+}

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -18,6 +18,7 @@ import MultiItem from "./components/MultiItem";
 
 const PolicyForm = () => {
   const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
+  const [pageNum, setPageNum] = useState<number>(0);
 
   const handleValueChange = (key: keyof FormState, value: FormValue) => {
     setFormState({
@@ -29,11 +30,14 @@ const PolicyForm = () => {
   const handleFormSubmit = () => {
     console.log(formState);
   };
+  const handleCLick = () => {
+    setPageNum(1);
+  };
 
   return (
     <div>
       <h1 className="my-2 text-4xl font-bold">Create a Policy</h1>
-      <form onSubmit={handleFormSubmit}>
+      <form>
         <h2 className="my-8 text-3xl font-bold">Policy details</h2>
 
         <div className="my-4">
@@ -98,7 +102,11 @@ const PolicyForm = () => {
           onChange={(value) => handleValueChange(SUPPLEMENTARY_TEXT_KEY, value)}
         />
 
-        <button className="mt-8 bg-green-700 hover:bg-green-800 text-white py-1 px-2">
+        <button
+          type="button"
+          className="mt-8 bg-green-700 hover:bg-green-800 text-white py-1 px-2"
+          onClick={handleFormSubmit}
+        >
           Save
         </button>
       </form>

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -18,7 +18,6 @@ import MultiItem from "./components/MultiItem";
 
 const PolicyForm = () => {
   const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
-  const [pageNum, setPageNum] = useState<number>(0);
 
   const handleValueChange = (key: keyof FormState, value: FormValue) => {
     setFormState({
@@ -29,9 +28,6 @@ const PolicyForm = () => {
 
   const handleFormSubmit = () => {
     console.log(formState);
-  };
-  const handleCLick = () => {
-    setPageNum(1);
   };
 
   return (

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -3,7 +3,7 @@ const PolicyPage = () => {
     <div>
       <div>
         <h1 className="my-8 text-3xl font-bold">
-          BR1234 - Brimingham Local Plan Policy
+          BR1234 - Birmingham Local Plan Policy
         </h1>
         <p className="w-2/3 text-lg mb-8">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -1,0 +1,47 @@
+const PolicyPage = () => {
+  return (
+    <div>
+      <div>
+        <h1 className="my-8 text-3xl font-bold">
+          BR1234 - Brimingham Local Plan Policy
+        </h1>
+        <p className="w-2/3 text-lg mb-8">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+        <hr className="my-8"></hr>
+        <h2 className="mt-8 text-xl font-bold">
+          Themes this policy is linked to:
+        </h2>
+        <p className="text-sm">Themes placeholder</p>
+        <p className="text-sm">Themes placeholder</p>
+        <p className="text-sm">Themes placeholder</p>
+        <p className="text-sm">Themes placeholder</p>
+
+        <h2 className="mt-8 text-xl font-bold">Requirements for policy:</h2>
+        <p className="text-sm">Requirements placeholder</p>
+        <p className="text-sm">Requirements placeholder</p>
+        <p className="text-sm">Requirements placeholder</p>
+        <p className="text-sm">Requirements placeholder</p>
+
+        <p className="w-2/3 text-lg mb-8 mt-6">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+        <div>boundary placeholder</div>
+      </div>
+    </div>
+  );
+};
+
+export default PolicyPage;

--- a/dluhc-component-library/src/stories/PolicyPage.stories.tsx
+++ b/dluhc-component-library/src/stories/PolicyPage.stories.tsx
@@ -1,0 +1,11 @@
+import PolicyPage from "../components/policyPage/PolicyPage.tsx";
+
+export default {
+  component: PolicyPage,
+  title: "SOW14/Policy Page",
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {},
+};


### PR DESCRIPTION
Adds the policy form visualization  skeleton
- adds the story
- adds the policy form visualization page
- adds mock json data to be used in next pr
- changes button in form to be onclick (andy)

![image](https://github.com/digital-land/plan-making/assets/110818566/a5d2c04f-002e-4fd0-8bae-93740c31fcbc)
