### PR TITLE
change Policy form to use json

### DIFF
--- a/dluhc-component-library/plan-making/assets/policy.json
+++ b/dluhc-component-library/plan-making/assets/policy.json
@@ -1,7 +1,7 @@
 {
-  "reference": "1234",
-  "title": "test policy title",
-  "description": "this is a test policy",
+  "reference": "NE1234",
+  "title": "Test Policy Title",
+  "description": "This is a test policy used to demonstarte how the policy page works. this description can be a brief overview of the policys input into the prior form.",
   "requirements": ["req1", "req2", "req3"],
   "boundary": [
     [
@@ -13,5 +13,5 @@
     ]
   ],
   "themes": ["artsCultureHeritage"],
-  "supplementaryText": "extra text for the policy"
+  "supplementaryText": "Here is some extra text for the policy, where any extra information can be added."
 }

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -5,7 +5,7 @@ import {
   BOUNDARY_KEY,
   DESCRIPTION_KEY,
   FORM_lABELS,
-  INITIAL_FORM_STATE,
+  INITIAL_POLICY_STATE,
   REFERENCE_KEY,
   REQUIREMENTS,
   SUPPLEMENTARY_TEXT_KEY,
@@ -13,13 +13,13 @@ import {
   THEME_OPTIONS,
   TITLE_KEY,
 } from "./constants";
-import { FormState, FormValue } from "./types";
+import { FormValue, PolicyState } from "./types";
 import MultiItem from "./components/MultiItem";
 
 const PolicyForm = () => {
-  const [formState, setFormState] = useState<FormState>(INITIAL_FORM_STATE);
+  const [formState, setFormState] = useState<PolicyState>(INITIAL_POLICY_STATE);
 
-  const handleValueChange = (key: keyof FormState, value: FormValue) => {
+  const handleValueChange = (key: keyof PolicyState, value: FormValue) => {
     setFormState({
       ...formState,
       [key]: value,

--- a/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
+++ b/dluhc-component-library/src/components/policyForm/PolicyForm.tsx
@@ -13,13 +13,13 @@ import {
   THEME_OPTIONS,
   TITLE_KEY,
 } from "./constants";
-import { FormValue, PolicyState } from "./types";
+import { FormValue, Policy } from "./types";
 import MultiItem from "./components/MultiItem";
 
 const PolicyForm = () => {
-  const [formState, setFormState] = useState<PolicyState>(INITIAL_POLICY_STATE);
+  const [formState, setFormState] = useState<Policy>(INITIAL_POLICY_STATE);
 
-  const handleValueChange = (key: keyof PolicyState, value: FormValue) => {
+  const handleValueChange = (key: keyof Policy, value: FormValue) => {
     setFormState({
       ...formState,
       [key]: value,

--- a/dluhc-component-library/src/components/policyForm/constants.ts
+++ b/dluhc-component-library/src/components/policyForm/constants.ts
@@ -1,4 +1,4 @@
-import { PolicyState } from "./types";
+import { Policy } from "./types";
 
 export const REFERENCE_KEY = "reference";
 export const TITLE_KEY = "title";
@@ -18,7 +18,7 @@ export const FORM_lABELS = {
   [SUPPLEMENTARY_TEXT_KEY]: "Text 1.1",
 };
 
-export const INITIAL_POLICY_STATE: PolicyState = {
+export const INITIAL_POLICY_STATE: Policy = {
   [REFERENCE_KEY]: "",
   [TITLE_KEY]: "",
   [DESCRIPTION_KEY]: "",

--- a/dluhc-component-library/src/components/policyForm/constants.ts
+++ b/dluhc-component-library/src/components/policyForm/constants.ts
@@ -1,4 +1,4 @@
-import { FormState } from "./types";
+import { PolicyState } from "./types";
 
 export const REFERENCE_KEY = "reference";
 export const TITLE_KEY = "title";
@@ -18,7 +18,7 @@ export const FORM_lABELS = {
   [SUPPLEMENTARY_TEXT_KEY]: "Text 1.1",
 };
 
-export const INITIAL_FORM_STATE: FormState = {
+export const INITIAL_POLICY_STATE: PolicyState = {
   [REFERENCE_KEY]: "",
   [TITLE_KEY]: "",
   [DESCRIPTION_KEY]: "",

--- a/dluhc-component-library/src/components/policyForm/types.ts
+++ b/dluhc-component-library/src/components/policyForm/types.ts
@@ -9,7 +9,7 @@ import {
   TITLE_KEY,
 } from "./constants";
 
-export interface FormState {
+export interface PolicyState {
   [REFERENCE_KEY]: string;
   [TITLE_KEY]: string;
   [DESCRIPTION_KEY]: string;
@@ -18,4 +18,5 @@ export interface FormState {
   [THEMES_KEY]: ReadonlyArray<string>;
   [SUPPLEMENTARY_TEXT_KEY]: string;
 }
-export type FormValue = FormState[keyof FormState];
+
+export type FormValue = PolicyState[keyof PolicyState];

--- a/dluhc-component-library/src/components/policyForm/types.ts
+++ b/dluhc-component-library/src/components/policyForm/types.ts
@@ -19,4 +19,14 @@ export interface FormState {
   [SUPPLEMENTARY_TEXT_KEY]: string;
 }
 
+export interface PolicyData {
+  reference: number;
+  title: string;
+  description: string;
+  requirements: string[];
+  boundary: number[][];
+  themes: string[];
+  supplementaryText: string;
+}
+
 export type FormValue = FormState[keyof FormState];

--- a/dluhc-component-library/src/components/policyForm/types.ts
+++ b/dluhc-component-library/src/components/policyForm/types.ts
@@ -18,15 +18,4 @@ export interface FormState {
   [THEMES_KEY]: ReadonlyArray<string>;
   [SUPPLEMENTARY_TEXT_KEY]: string;
 }
-
-export interface PolicyData {
-  reference: number;
-  title: string;
-  description: string;
-  requirements: string[];
-  boundary: number[][];
-  themes: string[];
-  supplementaryText: string;
-}
-
 export type FormValue = FormState[keyof FormState];

--- a/dluhc-component-library/src/components/policyForm/types.ts
+++ b/dluhc-component-library/src/components/policyForm/types.ts
@@ -9,7 +9,7 @@ import {
   TITLE_KEY,
 } from "./constants";
 
-export interface PolicyState {
+export interface Policy {
   [REFERENCE_KEY]: string;
   [TITLE_KEY]: string;
   [DESCRIPTION_KEY]: string;
@@ -19,4 +19,4 @@ export interface PolicyState {
   [SUPPLEMENTARY_TEXT_KEY]: string;
 }
 
-export type FormValue = PolicyState[keyof PolicyState];
+export type FormValue = Policy[keyof Policy];

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -1,8 +1,41 @@
-const PolicyPage = () => {
+import { useEffect, useState } from "react";
+import { PolicyData } from "../policyForm/types";
+import { loadCSV, loadJson } from "src/utils";
+interface PolicyPageProps {
+  policyFilePath: string;
+}
+
+const DEFAULT_POLICY_DATA: PolicyData = {
+  reference: 0,
+  title: "",
+  description: "",
+  requirements: [],
+  boundary: [],
+  themes: [],
+  supplementaryText: "",
+};
+
+const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
+  const [policyData, setPolicyData] = useState<PolicyData>(DEFAULT_POLICY_DATA);
+
+  const loadData = async () => {
+    if (/.json$/.test(policyFilePath)) {
+      await loadJson(policyFilePath).then((data) => {
+        setPolicyData(data);
+      });
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, [setPolicyData, policyFilePath]);
+
   return (
     <div>
       <div>
         <h1 className="my-8 text-3xl font-bold">
+          {policyData.reference}
+          {policyData.description}
           BR1234 - Birmingham Local Plan Policy
         </h1>
         <p className="w-2/3 text-lg mb-8">
@@ -45,3 +78,6 @@ const PolicyPage = () => {
 };
 
 export default PolicyPage;
+function csvToJson() {
+  throw new Error("Function not implemented.");
+}

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
-import { FormState } from "../policyForm/types";
 import { loadJson } from "src/utils";
-import { INITIAL_FORM_STATE } from "../policyForm/constants";
+import { PolicyState } from "../policyForm/types";
+import { INITIAL_POLICY_STATE } from "../policyForm/constants";
 interface PolicyPageProps {
   policyFilePath: string;
 }
 
 const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
-  const [policyData, setPolicyData] = useState<FormState>(INITIAL_FORM_STATE);
+  const [policyData, setPolicyData] =
+    useState<PolicyState>(INITIAL_POLICY_STATE);
 
   const loadData = async () => {
     if (/.json$/.test(policyFilePath)) {

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useState } from "react";
 import { loadJson } from "src/utils";
-import { PolicyState } from "../policyForm/types";
+import { Policy } from "../policyForm/types";
 import { INITIAL_POLICY_STATE } from "../policyForm/constants";
 interface PolicyPageProps {
   policyFilePath: string;
 }
 
 const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
-  const [policyData, setPolicyData] =
-    useState<PolicyState>(INITIAL_POLICY_STATE);
+  const [policyData, setPolicyData] = useState<Policy>(INITIAL_POLICY_STATE);
 
   const loadData = async () => {
     if (/.json$/.test(policyFilePath)) {

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -1,22 +1,13 @@
 import { useEffect, useState } from "react";
-import { PolicyData } from "../policyForm/types";
+import { FormState } from "../policyForm/types";
 import { loadJson } from "src/utils";
+import { INITIAL_FORM_STATE } from "../policyForm/constants";
 interface PolicyPageProps {
   policyFilePath: string;
 }
 
-const DEFAULT_POLICY_DATA: PolicyData = {
-  reference: 0,
-  title: "",
-  description: "",
-  requirements: [],
-  boundary: [],
-  themes: [],
-  supplementaryText: "",
-};
-
 const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
-  const [policyData, setPolicyData] = useState<PolicyData>(DEFAULT_POLICY_DATA);
+  const [policyData, setPolicyData] = useState<FormState>(INITIAL_FORM_STATE);
 
   const loadData = async () => {
     if (/.json$/.test(policyFilePath)) {
@@ -42,11 +33,15 @@ const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
           Themes this policy is linked to:
         </h2>
         {policyData.themes.map((theme) => (
-          <p className="text-sm">{theme}</p>
+          <p key={theme} className="text-sm">
+            {theme}
+          </p>
         ))}
         <h2 className="mt-8 text-xl font-bold">Requirements for policy:</h2>
-        {policyData.requirements.map((requirements) => (
-          <p className="text-sm">{requirements}</p>
+        {policyData.requirements.map((requirement) => (
+          <p key={requirement} className="text-sm">
+            {requirement}
+          </p>
         ))}
         <p className="w-2/3 text-lg mb-8 mt-6">
           {policyData.supplementaryText}

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { PolicyData } from "../policyForm/types";
-import { loadCSV, loadJson } from "src/utils";
+import { loadJson } from "src/utils";
 interface PolicyPageProps {
   policyFilePath: string;
 }
@@ -34,42 +34,22 @@ const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
     <div>
       <div>
         <h1 className="my-8 text-3xl font-bold">
-          {policyData.reference}
-          {policyData.description}
-          BR1234 - Birmingham Local Plan Policy
+          {policyData.reference} - {policyData.title}
         </h1>
-        <p className="w-2/3 text-lg mb-8">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum.
-        </p>
+        <p className="w-2/3 text-lg mb-8">{policyData.description}</p>
         <hr className="my-8"></hr>
         <h2 className="mt-8 text-xl font-bold">
           Themes this policy is linked to:
         </h2>
-        <p className="text-sm">Themes placeholder</p>
-        <p className="text-sm">Themes placeholder</p>
-        <p className="text-sm">Themes placeholder</p>
-        <p className="text-sm">Themes placeholder</p>
-
+        {policyData.themes.map((theme) => (
+          <p className="text-sm">{theme}</p>
+        ))}
         <h2 className="mt-8 text-xl font-bold">Requirements for policy:</h2>
-        <p className="text-sm">Requirements placeholder</p>
-        <p className="text-sm">Requirements placeholder</p>
-        <p className="text-sm">Requirements placeholder</p>
-        <p className="text-sm">Requirements placeholder</p>
-
+        {policyData.requirements.map((requirements) => (
+          <p className="text-sm">{requirements}</p>
+        ))}
         <p className="w-2/3 text-lg mb-8 mt-6">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum.
+          {policyData.supplementaryText}
         </p>
         <div>boundary placeholder</div>
       </div>
@@ -78,6 +58,3 @@ const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
 };
 
 export default PolicyPage;
-function csvToJson() {
-  throw new Error("Function not implemented.");
-}

--- a/dluhc-component-library/src/stories/PolicyPage.stories.tsx
+++ b/dluhc-component-library/src/stories/PolicyPage.stories.tsx
@@ -7,5 +7,7 @@ export default {
 };
 
 export const Default = {
-  args: {},
+  args: {
+    policyFilePath: "/plan-making/assets/policy.json",
+  },
 };


### PR DESCRIPTION
changed the policy form to now use the data given from the json file produced by the policy form.

![image](https://github.com/digital-land/plan-making/assets/110818566/805083e5-c676-4d4c-8a40-ec744631d641)
