### PR TITLE
BugFix - Fix Multiselect options in dynamic form

### DIFF
--- a/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
+++ b/dluhc-component-library/src/components/siteSelectionForm/components/DynamicForm.tsx
@@ -13,7 +13,7 @@ import {
   UiPropertySchema,
   Widget,
 } from "../types";
-import { convertPropertyToOptions } from "../utils";
+import { convertEnumsToOptions, convertPropertyToOptions } from "../utils";
 import MapPage from "./MapPage";
 
 interface DynamicFormProps {
@@ -72,7 +72,7 @@ const DynamicForm = ({
     case InputType.MultiSelect:
       questionInputComponent = (
         <MultiSelect
-          options={formPageSchema.enum as ReadonlyArray<string>}
+          options={convertEnumsToOptions(formPageSchema.enum ?? [])}
           values={value as Array<string>}
           onChange={handleFormValueChange}
         />

--- a/dluhc-component-library/src/components/siteSelectionForm/types.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/types.ts
@@ -24,7 +24,12 @@ export interface FormPageSchema {
   items?: FormPageSchema;
 }
 
-export type FormValue = string | number | boolean | Array<string> | Boundary;
+export type FormValue =
+  | string
+  | number
+  | boolean
+  | ReadonlyArray<string>
+  | Boundary;
 
 export type FormState = Record<string, FormValue>;
 

--- a/dluhc-component-library/src/components/siteSelectionForm/utils.ts
+++ b/dluhc-component-library/src/components/siteSelectionForm/utils.ts
@@ -23,10 +23,19 @@ export const convertPropertyToOptions: (
   return [];
 };
 
+export const convertEnumsToOptions: (
+  enums: ReadonlyArray<string>,
+) => ReadonlyArray<{ key: string; label: string }> = (
+  enums: ReadonlyArray<string>,
+) => {
+  return enums.map((value) => ({ key: value, label: value }));
+};
+
 export const isArrayValidationShape = (
   property: FormPageSchema,
   validationShape: ValidationShape,
-): validationShape is ValidationArraySchema => property?.type === "array";
+): validationShape is ValidationArraySchema =>
+  validationShape && property?.type === "array";
 
 export const REQUIRED_MESSAGE = "This field is required.";
 


### PR DESCRIPTION
A recent change [(DLUHC-203)](https://github.com/digital-land/plan-making/pull/79/files) broke multiselect in the site identification form. This is because it converted the options from strings to keys and labels.

This PR fixes that by adding a new util that converts an enums to valid options. 

Also fixed a TSlint issue with `validationShape` not being used.

![image](https://github.com/digital-land/plan-making/assets/97245023/b88b9701-7aca-4e4c-b53e-231f77a1bd0f)

**Notes**

The options of multiselect and radio buttons should be linked up. This is a little hard since radio buttons also allow booleans but it should be investigated in the future.
