### PR TITLE
MISC Format policy page lists

### DIFF
--- a/dluhc-component-library/plan-making/assets/policy.json
+++ b/dluhc-component-library/plan-making/assets/policy.json
@@ -1,21 +1,35 @@
 {
-  "reference": "NE1234",
-  "title": "Test Policy Title",
-  "description": "This is a test policy used to demonstarte how the policy page works. this description can be a brief overview of the policys input into the prior form.",
-  "requirements": ["req1", "req2", "req3"],
+  "reference": "PLY11",
+  "title": "Cornwall Street West, City Centre",
+  "description": "Land at Cornwall Street West is allocated for mixed use, including commercial and housing, retention of coach station and new multi-storey car parks accessed from Mayflower Street.  Provision is made for in the order of 79 homes.  ",
+  "requirements": [
+    "High quality design to replace poorer quality developments and deliver a greater level of activity, floorspace and diversity of land uses. ",
+    "Buildings of between 5-6 storeys in height.",
+    "An enhanced arrival point to the City Centre providing for high quality public car parking in a multi-storey format with vehicular access direct from Mayflower Street and seamless pedestrian connections into Cornwall Street.",
+    "A north / south connection through the block which provides smaller scale spaces in the City Centre to support a greater range of land uses. ",
+    "Enhanced setting of the coach station with new build frontage and improved direct pedestrian and cycle access to the car park and to all surrounding streets.",
+    "Further enhancements as required to support a high quality of environment and facilities at the coach station."
+  ],
   "boundary": [
     [
-      [-1.9332955613569025, 55.02451876227576],
-      [-1.9167930901603967, 55.019563404930295],
-      [-1.8810377359013006, 55.011678619347435],
-      [-1.8676785925517483, 55.023617833775745],
-      [-1.861784852838711, 55.031275080585004],
-      [-1.851176121355243, 55.04253308016297],
-      [-1.8547123651830657, 55.046810290566526],
-      [-1.8822164838439084, 55.05086196330697],
-      [-1.9211151659499577, 55.04590986317646]
+      [-4.144253133644764, 50.37329529248319],
+      [-4.1442475087434785, 50.37304416915168],
+      [-4.145130618245107, 50.37304775663719],
+      [-4.145140921101501, 50.372642996486576],
+      [-4.144241883842195, 50.37265671911854],
+      [-4.144241883842195, 50.372387654733956],
+      [-4.145889979918479, 50.37235536690528],
+      [-4.1458956048197635, 50.37325583033339],
+      [-4.144253133644764, 50.37329529248319]
     ]
   ],
-  "themes": ["artsCultureHeritage"],
-  "supplementaryText": "Here is some extra text for the policy, where any extra information can be added."
+  "themes": [
+    "artsCultureHeritage",
+    "economy",
+    "environmentAndGreenspace",
+    "gettingAround",
+    "livingAndHousing",
+    "cityLife"
+  ],
+  "supplementaryText": ""
 }

--- a/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
+++ b/dluhc-component-library/src/components/policyPage/PolicyPage.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useState } from "react";
 import { loadJson } from "src/utils";
 import { Policy } from "../policyForm/types";
-import { INITIAL_POLICY_STATE } from "../policyForm/constants";
+import { INITIAL_POLICY_STATE, THEME_OPTIONS } from "../policyForm/constants";
 import MapComponent from "../maps/MapComponent";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 interface PolicyPageProps {
@@ -39,22 +39,30 @@ const PolicyPage = ({ policyFilePath }: PolicyPageProps) => {
         <h1 className="my-8 text-3xl font-bold">
           {policyData.reference} - {policyData.title}
         </h1>
-        <p className="w-2/3 text-lg mb-8">{policyData.description}</p>
-        <hr className="my-8"></hr>
-        <h2 className="mt-8 text-xl font-bold">
+        <p className="text-lg mb-8">{policyData.description}</p>
+        <h2 className="mt-8  mb-4  text-xl font-bold">
           Themes this policy is linked to:
         </h2>
-        {policyData.themes.map((theme) => (
-          <p key={theme} className="text-sm">
-            {theme}
-          </p>
-        ))}
-        <h2 className="mt-8 text-xl font-bold">Requirements for policy:</h2>
-        {policyData.requirements.map((requirement) => (
-          <p key={requirement} className="text-sm">
-            {requirement}
-          </p>
-        ))}
+        <ul className="list-disc pl-8">
+          {policyData.themes.map((theme) => (
+            <li key={theme} className="text-sm">
+              {
+                THEME_OPTIONS.find((themeObject) => themeObject.key === theme)
+                  ?.label
+              }
+            </li>
+          ))}
+        </ul>
+        <h2 className="mt-8 mb-4 text-xl font-bold">
+          Development should provide for the following:
+        </h2>
+        <ul className="list-disc pl-8">
+          {policyData.requirements.map((requirement) => (
+            <li key={requirement} className="text-sm mb-2">
+              {requirement}
+            </li>
+          ))}
+        </ul>
         <p className="w-2/3 text-lg mb-8 mt-6">
           {policyData.supplementaryText}
         </p>


### PR DESCRIPTION
Quick misc PR containing some of the changes done for screenshots in the final reports.

Updated the policy data to follow an existing plymouth policy page
Updated the css to be more uniform and display as bullet points
Updated the themes to display the correct human readable labels rather than keys.

![image](https://github.com/digital-land/plan-making/assets/97245023/c32cdac5-120c-4bed-9527-9a61e8f3babc)
